### PR TITLE
feat(install): add curl installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ config.json
 
 # Output playlist
 playlist.json
+
+# Release artifacts
+/release/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ npm i -g ff1-cli
 curl -fsSL https://feralfile.com/ff1-cli-install | bash
 ```
 
+Installs a prebuilt binary for macOS/Linux (no Node.js required).
+
 ## One-off Usage (npx)
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ npm i -g ff1-cli
 curl -fsSL https://feralfile.com/ff1-cli-install | bash
 ```
 
-Note: The curl installer uses npm, so Node.js + npm must be installed.
+Installs a prebuilt binary for macOS/Linux (no Node.js required).
 
 ## Configure
 
@@ -263,4 +263,5 @@ See selection rules and examples in `./CONFIGURATION.md`.
 
 - Function calling details: `./FUNCTION_CALLING.md`
 - Examples: `./EXAMPLES.md`
+- Release assets: `./RELEASING.md`
 - DP1 spec: `https://github.com/display-protocol/dp1`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,22 @@
+# Releasing Binary Assets
+
+The curl installer downloads prebuilt binaries from GitHub Releases. Build one asset per OS/arch and upload both the archive and its `.sha256` checksum.
+
+## Build a Release Asset (local)
+
+```bash
+./scripts/release/build-asset.sh
+```
+
+This produces:
+
+- `release/ff1-cli-darwin-x64.tar.gz`
+- `release/ff1-cli-darwin-x64.tar.gz.sha256`
+
+The exact filename depends on the OS/arch you build on. Run the script on each target platform (macOS + Linux, x64/arm64) and upload each pair to the GitHub release.
+
+## Environment Overrides
+
+- `FF1_CLI_VERSION`: overrides the version label in logs
+- `FF1_CLI_NODE_VERSION`: Node version to bundle (default: 20.12.2)
+- `FF1_CLI_OUTPUT_DIR`: output directory (default: `./release`)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "tsc",
     "bundle": "node build.js",
     "bundle:dev": "node build.js --dev",
+    "release:asset": "./scripts/release/build-asset.sh",
     "start": "node dist/index.js",
     "dev": "tsx index.ts",
     "prepublishOnly": "npm run build",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,38 +1,82 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-PACKAGE="ff1-cli"
-PREFIX_DEFAULT="$HOME/.local"
-PREFIX="${FF1_CLI_PREFIX:-$PREFIX_DEFAULT}"
+REPO="feral-file/ff1-cli"
+INSTALL_DIR_DEFAULT="$HOME/.local/ff1-cli"
+BIN_DIR_DEFAULT="$HOME/.local/bin"
 
-if ! command -v node >/dev/null 2>&1; then
-  echo "ff1-cli installer: Node.js is required but was not found."
-  echo "Install Node.js from https://nodejs.org/ and re-run this command."
+INSTALL_DIR="${FF1_CLI_INSTALL_DIR:-$INSTALL_DIR_DEFAULT}"
+BIN_DIR="${FF1_CLI_BIN_DIR:-$BIN_DIR_DEFAULT}"
+VERSION="${FF1_CLI_VERSION:-latest}"
+BASE_URL="${FF1_CLI_BASE_URL:-https://github.com/$REPO/releases}"
+
+OS_RAW="$(uname -s)"
+ARCH_RAW="$(uname -m)"
+
+case "$OS_RAW" in
+  Darwin)
+    OS="darwin"
+    ;;
+  Linux)
+    OS="linux"
+    ;;
+  *)
+    echo "ff1-cli installer: unsupported OS: $OS_RAW"
+    exit 1
+    ;;
+esac
+
+case "$ARCH_RAW" in
+  x86_64|amd64)
+    ARCH="x64"
+    ;;
+  arm64|aarch64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "ff1-cli installer: unsupported architecture: $ARCH_RAW"
+    exit 1
+    ;;
+esac
+
+ASSET="ff1-cli-$OS-$ARCH.tar.gz"
+CHECKSUM="$ASSET.sha256"
+
+if [ "$VERSION" = "latest" ]; then
+  DOWNLOAD_URL="$BASE_URL/latest/download/$ASSET"
+  CHECKSUM_URL="$BASE_URL/latest/download/$CHECKSUM"
+else
+  DOWNLOAD_URL="$BASE_URL/download/v$VERSION/$ASSET"
+  CHECKSUM_URL="$BASE_URL/download/v$VERSION/$CHECKSUM"
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "Downloading ff1-cli ($OS/$ARCH)..."
+curl -fsSL "$DOWNLOAD_URL" -o "$WORKDIR/$ASSET"
+curl -fsSL "$CHECKSUM_URL" -o "$WORKDIR/$CHECKSUM"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$WORKDIR" && sha256sum -c "$CHECKSUM")
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$WORKDIR" && shasum -a 256 -c "$CHECKSUM")
+else
+  echo "ff1-cli installer: missing sha256sum/shasum for verification."
   exit 1
 fi
 
-if ! command -v npm >/dev/null 2>&1; then
-  echo "ff1-cli installer: npm is required but was not found."
-  echo "Install npm with Node.js and re-run this command."
-  exit 1
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+tar -xzf "$WORKDIR/$ASSET" -C "$INSTALL_DIR" --strip-components=1
+
+ln -sf "$INSTALL_DIR/bin/ff1" "$BIN_DIR/ff1"
+
+if ! command -v ff1 >/dev/null 2>&1; then
+  echo "Installed ff1 to $BIN_DIR, but it is not on your PATH."
+  echo "Add this to your shell profile: export PATH=\"$BIN_DIR:\$PATH\""
+else
+  echo "ff1-cli installed. Run: ff1 --help"
 fi
-
-echo "Installing $PACKAGE..."
-
-if npm install -g "$PACKAGE"; then
-  echo "Installed $PACKAGE. Run: ff1 --help"
-  exit 0
-fi
-
-echo "Global install failed. Trying local prefix: $PREFIX"
-
-if npm install -g --prefix "$PREFIX" "$PACKAGE"; then
-  echo "Installed $PACKAGE to $PREFIX."
-  echo "Add to PATH: export PATH=\"$PREFIX/bin:\$PATH\""
-  echo "Then run: ff1 --help"
-  exit 0
-fi
-
-echo "Installation failed. You may need sudo or a writable npm prefix."
-echo "Try: npm install -g --prefix \"$PREFIX\" $PACKAGE"
-exit 1

--- a/scripts/release/build-asset.sh
+++ b/scripts/release/build-asset.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+OUTPUT_DIR="${FF1_CLI_OUTPUT_DIR:-$ROOT_DIR/release}"
+NODE_VERSION="${FF1_CLI_NODE_VERSION:-20.12.2}"
+VERSION="${FF1_CLI_VERSION:-$(node -p "require('$ROOT_DIR/package.json').version")}"
+
+OS_RAW="$(uname -s)"
+ARCH_RAW="$(uname -m)"
+
+case "$OS_RAW" in
+  Darwin)
+    OS="darwin"
+    NODE_OS="darwin"
+    ;;
+  Linux)
+    OS="linux"
+    NODE_OS="linux"
+    ;;
+  *)
+    echo "Unsupported OS: $OS_RAW"
+    exit 1
+    ;;
+esac
+
+case "$ARCH_RAW" in
+  x86_64|amd64)
+    ARCH="x64"
+    NODE_ARCH="x64"
+    ;;
+  arm64|aarch64)
+    ARCH="arm64"
+    NODE_ARCH="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH_RAW"
+    exit 1
+    ;;
+esac
+
+ASSET_NAME="ff1-cli-$OS-$ARCH"
+ARCHIVE_NAME="$ASSET_NAME.tar.gz"
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "Building ff1-cli bundle..."
+cd "$ROOT_DIR"
+npm ci
+npm run bundle
+npm prune --omit=dev
+
+NODE_ARCHIVE="node-v$NODE_VERSION-$NODE_OS-$NODE_ARCH.tar.gz"
+NODE_URL="https://nodejs.org/dist/v$NODE_VERSION/$NODE_ARCHIVE"
+
+echo "Downloading Node.js $NODE_VERSION ($NODE_OS/$NODE_ARCH)..."
+curl -fsSL "$NODE_URL" -o "$WORKDIR/$NODE_ARCHIVE"
+tar -xzf "$WORKDIR/$NODE_ARCHIVE" -C "$WORKDIR"
+
+PACKAGE_DIR="$WORKDIR/$ASSET_NAME"
+mkdir -p "$PACKAGE_DIR/bin" "$PACKAGE_DIR/lib" "$PACKAGE_DIR/node/bin"
+
+cp "$ROOT_DIR/dist/ff1.js" "$PACKAGE_DIR/lib/ff1.js"
+cp -R "$ROOT_DIR/node_modules" "$PACKAGE_DIR/lib/node_modules"
+cp "$WORKDIR/node-v$NODE_VERSION-$NODE_OS-$NODE_ARCH/bin/node" "$PACKAGE_DIR/node/bin/node"
+cp "$ROOT_DIR/LICENSE" "$PACKAGE_DIR/LICENSE"
+cp "$ROOT_DIR/README.md" "$PACKAGE_DIR/README.md"
+
+cat > "$PACKAGE_DIR/bin/ff1" <<'EOF'
+#!/usr/bin/env bash
+set -e
+BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+NODE="$BASE_DIR/node/bin/node"
+APP="$BASE_DIR/lib/ff1.js"
+exec "$NODE" "$APP" "$@"
+EOF
+
+chmod +x "$PACKAGE_DIR/bin/ff1"
+
+mkdir -p "$OUTPUT_DIR"
+tar -czf "$OUTPUT_DIR/$ARCHIVE_NAME" -C "$WORKDIR" "$ASSET_NAME"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$OUTPUT_DIR" && sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$OUTPUT_DIR" && shasum -a 256 "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256")
+else
+  echo "Missing sha256sum/shasum for checksum generation"
+  exit 1
+fi
+
+echo "Built $ARCHIVE_NAME (version $VERSION) in $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add a curl-based installer script that uses npm with a local-prefix fallback
- document curl install and update docs to use ff1 commands for global installs

## Notes
- depends on #10 for the npm install flow in README

## Testing
- not run (not requested)