### PR TITLE
docs: add curl installer guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ FF1-CLI turns a simple prompt into a DP-1–conformant playlist you can preview 
 npm i -g ff1-cli
 ```
 
+## Install (curl)
+
+```bash
+curl -fsSL https://feralfile.com/ff1-cli-install | bash
+```
+
+Installs a prebuilt binary for macOS/Linux (no Node.js required).
+
 ## One-off Usage (npx)
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,6 +15,16 @@ This produces:
 
 The exact filename depends on the OS/arch you build on. Run the script on each target platform (macOS + Linux, x64/arm64) and upload each pair to the GitHub release.
 
+## Installer Redirect
+
+`https://feralfile.com/ff1-cli-install` should redirect to:
+
+```
+https://raw.githubusercontent.com/feral-file/ff1-cli/main/scripts/install.sh
+```
+
+The installer script then fetches the release assets from GitHub Releases.
+
 ## Environment Overrides
 
 - `FF1_CLI_VERSION`: overrides the version label in logs


### PR DESCRIPTION
## Summary
- document the curl-based install command in the main README
- add a release note describing the feralfile.com installer redirect target

## Testing
- not run (docs-only change)