### PR TITLE
feat: add `ff1 device default <name>` to set the default device

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -123,6 +123,7 @@ You can also manage devices independently with:
 - `ff1 device add` – Add a device interactively (with mDNS discovery), or non-interactively with `--host` and `--name`.
 - `ff1 device list` – Show all configured devices.
 - `ff1 device remove <name>` – Remove a device by name.
+- `ff1 device default <name>` – Promote a device to the top of the list so it is used when `-d` is omitted.
 
 Setup and `device add` both preserve existing devices. Adding a device with the same host as an existing one updates it in place.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,6 +147,7 @@ Notes:
 - `device add` – Add a new FF1 device (with mDNS discovery)
   - Options: `--host <host>`, `--name <name>`
 - `device remove <name>` – Remove a configured FF1 device
+- `device default <name>` – Set the default FF1 device (used when `-d` is omitted)
 - `config <init|show|validate>` – Manage configuration
 
 ## Usage Highlights
@@ -309,6 +310,9 @@ ff1 device add --host 192.168.1.100 --name kitchen
 
 # Remove a device by name
 ff1 device remove kitchen
+
+# Set the default device (used when -d is omitted)
+ff1 device default office
 ```
 
 Setup preserves existing devices when adding new ones. See selection rules and examples in `./CONFIGURATION.md`.

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ import { isPlaylistSourceUrl, loadPlaylistSource } from './src/utilities/playlis
 import { upsertDevice } from './src/utilities/device-upsert';
 import { findExistingDeviceEntry } from './src/utilities/device-lookup';
 import { normalizeDeviceHost, normalizeDeviceIdToHost } from './src/utilities/device-normalize';
+import { promoteDeviceToDefault } from './src/utilities/device-default';
 
 // Load version from package.json
 // Try built location first (dist/index.js -> ../package.json)
@@ -1611,6 +1612,56 @@ deviceCommand
       await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
       console.log(chalk.green(`\nRemoved device: ${removed.name || removed.host}`));
       console.log(chalk.dim(`Remaining devices: ${updatedDevices.length}\n`));
+    } catch (error) {
+      console.error(chalk.red('\nError:'), (error as Error).message);
+      process.exit(1);
+    }
+  });
+
+deviceCommand
+  .command('default')
+  .description('Set the default FF1 device (reorders so this device is used when -d is omitted)')
+  .argument('<name>', 'Device name or host to promote to default')
+  .action(async (name: string) => {
+    try {
+      const configPath = await resolveExistingConfigPath();
+      if (!configPath) {
+        console.log(chalk.red('config.json not found'));
+        console.log(chalk.dim('Run: ff1 setup'));
+        process.exit(1);
+      }
+
+      const config = await readConfigFile(configPath);
+      const existingDevices = config.ff1Devices?.devices || [];
+
+      if (existingDevices.length === 0) {
+        console.log(chalk.yellow('\nNo devices configured'));
+        console.log(chalk.dim('Run: ff1 device add\n'));
+        process.exit(1);
+      }
+
+      let result;
+      try {
+        result = promoteDeviceToDefault(existingDevices, name);
+      } catch (error) {
+        console.error(chalk.red(`\n${(error as Error).message}`));
+        const names = existingDevices.map((d) => d.name || d.host).join(', ');
+        console.log(chalk.dim(`Available devices: ${names}\n`));
+        process.exit(1);
+      }
+
+      const label = result.promoted.name || result.promoted.host;
+
+      if (result.alreadyDefault) {
+        console.log(chalk.dim(`\n"${label}" is already the default.\n`));
+        return;
+      }
+
+      config.ff1Devices = { devices: result.devices };
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+
+      console.log(chalk.green(`\nDefault device: ${label}`));
+      console.log(chalk.dim('Other commands now target this device when -d is omitted.\n'));
     } catch (error) {
       console.error(chalk.red('\nError:'), (error as Error).message);
       process.exit(1);

--- a/src/utilities/device-default.ts
+++ b/src/utilities/device-default.ts
@@ -1,0 +1,51 @@
+import { normalizeDeviceHost } from './device-normalize';
+import type { DeviceEntry } from './device-upsert';
+
+export interface PromoteDefaultResult {
+  devices: DeviceEntry[];
+  promoted: DeviceEntry;
+  /** True when the target was already at index 0; callers can skip persisting. */
+  alreadyDefault: boolean;
+}
+
+/**
+ * Move the named device to index 0 so it becomes the implicit default.
+ *
+ * Matches by name (case-insensitive) or by host URL, mirroring `device remove`
+ * so unnamed legacy entries can still be targeted.
+ *
+ * @throws {Error} When no device matches the identifier
+ */
+export function promoteDeviceToDefault(
+  devices: DeviceEntry[],
+  identifier: string
+): PromoteDefaultResult {
+  const normalizedArg = identifier.toLowerCase();
+  let normalizedArgHost = '';
+  try {
+    normalizedArgHost = normalizeDeviceHost(identifier).toLowerCase();
+  } catch {
+    // not a valid URL — host matching will not apply
+  }
+
+  const index = devices.findIndex(
+    (d) =>
+      (d.name && d.name.toLowerCase() === normalizedArg) ||
+      (d.host && d.host.toLowerCase() === normalizedArg) ||
+      (normalizedArgHost &&
+        d.host &&
+        normalizeDeviceHost(d.host).toLowerCase() === normalizedArgHost)
+  );
+
+  if (index === -1) {
+    throw new Error(`Device "${identifier}" not found`);
+  }
+
+  const promoted = devices[index];
+  if (index === 0) {
+    return { devices: [...devices], promoted, alreadyDefault: true };
+  }
+
+  const reordered = [promoted, ...devices.slice(0, index), ...devices.slice(index + 1)];
+  return { devices: reordered, promoted, alreadyDefault: false };
+}

--- a/tests/device-default.test.ts
+++ b/tests/device-default.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { promoteDeviceToDefault } from '../src/utilities/device-default';
+import type { DeviceEntry } from '../src/utilities/device-upsert';
+
+const sample = (): DeviceEntry[] => [
+  { name: 'kitchen', host: 'http://192.168.1.10:1111', id: 'ff1-kkk' },
+  { name: 'office', host: 'http://192.168.1.11:1111', id: 'ff1-ooo' },
+  { name: 'studio', host: 'http://192.168.1.12:1111' },
+];
+
+describe('promoteDeviceToDefault', () => {
+  test('moves the named device to index 0 and preserves the rest in order', () => {
+    const { devices, promoted, alreadyDefault } = promoteDeviceToDefault(sample(), 'office');
+    assert.equal(alreadyDefault, false);
+    assert.equal(promoted.name, 'office');
+    assert.deepEqual(
+      devices.map((d) => d.name),
+      ['office', 'kitchen', 'studio']
+    );
+  });
+
+  test('is case-insensitive on name', () => {
+    const { devices } = promoteDeviceToDefault(sample(), 'OFFICE');
+    assert.equal(devices[0].name, 'office');
+  });
+
+  test('matches by host URL for unnamed/legacy entries', () => {
+    const devices: DeviceEntry[] = [
+      { name: 'kitchen', host: 'http://192.168.1.10:1111' },
+      { host: 'http://192.168.1.99:1111' },
+    ];
+    const result = promoteDeviceToDefault(devices, 'http://192.168.1.99:1111');
+    assert.equal(result.devices[0].host, 'http://192.168.1.99:1111');
+    assert.equal(result.devices[1].name, 'kitchen');
+  });
+
+  test('reports alreadyDefault when the target is already first', () => {
+    const { devices, alreadyDefault } = promoteDeviceToDefault(sample(), 'kitchen');
+    assert.equal(alreadyDefault, true);
+    assert.deepEqual(
+      devices.map((d) => d.name),
+      ['kitchen', 'office', 'studio']
+    );
+  });
+
+  test('throws when identifier does not match any device', () => {
+    assert.throws(() => promoteDeviceToDefault(sample(), 'bathroom'), /not found/);
+  });
+
+  test('does not mutate the input array', () => {
+    const input = sample();
+    const before = input.map((d) => d.name);
+    promoteDeviceToDefault(input, 'office');
+    assert.deepEqual(
+      input.map((d) => d.name),
+      before
+    );
+  });
+});


### PR DESCRIPTION
## Problem

With multiple devices configured, there was no way to set which one is the default — the CLI always falls back to `devices[0]`, and the only way to change that was to hand-edit `config.json`. Users with two devices (e.g. kitchen + office) had to pass `-d <name>` on every `chat`, `send`, `play`, and `ssh` call.

## Why It Matters

Small usability win for the common multi-device case. No new config shape, no migration — just reorder the existing array so the implicit default matches user preference.

## What changed

- New `ff1 device default <name>` subcommand that reorders `ff1Devices.devices` so the named device is first.
- Matches by name (case-insensitive) or host URL, mirroring `device remove`.
- Reports `"<name>" is already the default` without writing when no reorder is needed.
- Pure helper extracted to `src/utilities/device-default.ts` with unit tests covering reorder, case-insensitivity, host-match, no-op, not-found, and input immutability.
- Docs updated in `docs/README.md` and `docs/CONFIGURATION.md`.

`-d <name>` continues to work as a per-call override; nothing else changes.

## Acceptance Checks

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 137 tests, 0 fail (6 new tests for the helper)
- [x] `npm run smoke` passes
- [x] `ff1 device --help` shows the new subcommand

## Human Owner

@seanmosspultz

## How The Agent Will Be Used

Agent implemented the subcommand, the pure reorder helper, unit tests, and doc updates.

## PR or Deploy Link

N/A until merged — release cut via GitHub release after merge.