### PR TITLE
docs: align ff1-cli verification guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check formatting
-        run: npm run format:check
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Run tests
-        run: npm test
-
-      - name: Build TypeScript
-        run: npm run build
-
-      - name: Smoke test playlist validation
-        run: node dist/index.js validate examples/sample-playlist.json
-
-      - name: Smoke test config validation
-        run: node dist/index.js config validate
+      - name: Verify
+        run: npm run verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,12 +85,10 @@ For behavior changes:
 Required verification commands:
 
 ```bash
-npm run lint:fix
-npm test
-npm run build
-GROK_API_KEY=dummy node dist/index.js validate examples/sample-playlist.json
-GROK_API_KEY=dummy node dist/index.js config validate
+GROK_API_KEY=dummy npm run verify
 ```
+
+This is the same non-mutating entrypoint used by `.github/workflows/ci.yml` after `npm ci` on Node.js 22. Use `npm run lint:fix` only as an optional mutating cleanup step, then review and verify the resulting edits before committing.
 
 If strict test-first sequencing is not practical, call out the reason in the handoff or final summary.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ff1 config validate
 **Set your LLM API key first (default Grok):** `export GROK_API_KEY='xai-your-api-key-here'`
 
 ```bash
-npm install
+npm ci
 npm run dev -- setup
 npm run dev -- chat
 npm run dev -- play "https://example.com/video.mp4" --skip-verify
@@ -61,14 +61,32 @@ npm run dev -- play "https://example.com/video.mp4" --skip-verify
 - Examples: `./docs/EXAMPLES.md`
 - SSH access: `ff1 ssh enable|disable` in `./docs/README.md`
 
+## Verification
+
+GitHub Actions runs `.github/workflows/ci.yml` for pull requests, pushes to `main`/`master`, and reusable `workflow_call` jobs. CI uses Node.js 22, installs dependencies with `npm ci`, sets `GROK_API_KEY=dummy`, and runs the repo-wide verification entrypoint:
+
+```bash
+GROK_API_KEY=dummy npm run verify
+```
+
+Run the same command locally before opening a PR. It checks formatting, lint, tests, TypeScript build, playlist validation smoke, and config validation smoke without mutating source files.
+
+Other GitHub Actions workflows:
+
+- `.github/workflows/build.yml` builds release assets when called by release automation or manually dispatched.
+- `.github/workflows/release.yml` reuses CI, verifies the release version, publishes npm, uploads assets, and checks the published release.
+- `.github/workflows/dependency-review.yml` reviews dependency changes on pull requests.
+- `.github/workflows/codeql.yml` runs CodeQL analysis on pull requests and pushes to `main`/`master`.
+
 ## Scripts
 
 ```bash
 npm run dev            # Run CLI in dev (tsx)
 npm run build          # Build TypeScript
-npm run lint:fix       # Lint + fix
+npm run check          # Format check + lint + tests
 npm run smoke          # Build + CLI smoke checks
-npm run verify         # Format + lint + test + smoke
+npm run verify         # CI-equivalent validation entrypoint
+npm run lint:fix       # Optional mutating lint fix; review changes before committing
 ```
 
 ## License


### PR DESCRIPTION
## Problem
The README did not accurately describe the GitHub Actions CI surface or the local CI-equivalent verification path. It also listed the mutating `npm run lint:fix` command beside validation commands, while `AGENTS.md` pointed at a different multi-command verification flow.

## Why It Matters
Contributors and coding agents need one dependable, non-mutating repo-wide verification entrypoint that matches CI. Keeping GitHub Actions and local guidance aligned reduces false confidence before PRs and avoids accidental source mutations during validation.

## Acceptance Checks
- README documents GitHub Actions CI triggers/runtime/install behavior and the local `GROK_API_KEY=dummy npm run verify` path.
- CI reuses the same `npm run verify` entrypoint after `npm ci` instead of duplicating the logical checks inline.
- AGENTS points at the same non-mutating verification entrypoint and labels `npm run lint:fix` as optional/mutating cleanup.

## Validation Run
- `node --version` -> `v25.9.0` locally; CI remains configured for Node.js 22.
- `npm --version` -> `11.12.1`.
- `npm ci` completed successfully; npm audit reported existing dependency vulnerabilities.
- `GROK_API_KEY=dummy npm run verify` passed: format check, lint, 140 tests, TypeScript build, playlist validation smoke, and config validation smoke.

Fixes https://github.com/feral-file/ffos-user/issues/162
