### PR TITLE
ci: cross-platform verify matrix + pre-commit hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Force LF line endings for all text files on every platform.
+# Windows runners default to CRLF on checkout via core.autocrlf, which causes
+# prettier (configured with endOfLine: "lf") to flag every file as needing
+# reformatting. This pins the working-tree to LF regardless of OS.
+* text=auto eol=lf
+
+# Binary files: do not normalize.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     env:
       GROK_API_KEY: dummy
     steps:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run check

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^9.36.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
+        "husky": "^9.1.7",
         "prettier": "^3.6.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
@@ -2145,6 +2146,22 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bundle": "node build.js",
     "bundle:dev": "node build.js --dev",
     "release:asset": "./scripts/release/build-asset.sh",
+    "prepare": "husky",
     "start": "node dist/index.js",
     "dev": "tsx index.ts",
     "smoke": "npm run build && node dist/index.js validate examples/sample-playlist.json && node dist/index.js config validate",
@@ -66,6 +67,7 @@
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
- Add macos-latest and windows-latest to the CI verify matrix. The single-OS (ubuntu) matrix recently let two platform-specific issues ship to main: a prettier formatting failure on the unified `play` command and a Windows-only `spawnSync` regression in the `device default` integration test. Both would have been caught here.
- Add a husky pre-commit hook that runs `npm run check` (format check + lint + tests). Formatting failures cannot reach `main` even by accident.

## Test plan
- [ ] CI passes on all three platforms in this PR.
- [ ] Local `npm install` runs `prepare` and installs the husky hook.
- [ ] `git commit` triggers `npm run check` and rejects if it fails.