### PR TITLE
build: add cut-release.sh to atomically tag, push, and publish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,10 @@ Tool mappings:
 - Prefer separate commits for large legacy removal when that clarifies review.
 - PR or handoff summaries should include goal, scope, decisions, tests, and remaining risks.
 
+## Cutting a release
+
+Always use `./scripts/release/cut-release.sh <patch|minor|major|x.y.z>` from a clean `main` checked out at `origin/main`. The script bumps `package.json` + `package-lock.json`, commits, tags, pushes, and creates the GitHub Release in one atomic flow. The GitHub Release event is what triggers `release.yml` and the npm publish — pushing a tag without creating a Release will silently skip the publish.
+
 ## Authoritative tool-specific files
 
 - Cursor rules: `.cursor/rules/`

--- a/scripts/release/cut-release.sh
+++ b/scripts/release/cut-release.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Atomic release cutter: bump version, push tag, create GitHub Release.
+# Usage: ./scripts/release/cut-release.sh <patch|minor|major|x.y.z>
+#
+# Three releases (1.0.13–1.0.15) silently failed to publish to npm because
+# tags were pushed without the corresponding GitHub Release that triggers
+# the publish workflow. This script makes the three steps atomic.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <patch|minor|major|x.y.z>" >&2
+  exit 2
+fi
+
+BUMP="$1"
+
+# Refuse to cut from anywhere but a clean main checked out at origin/main.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" != "main" ]; then
+  echo "error: must be on main, currently on '$BRANCH'" >&2
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is dirty; commit or stash first" >&2
+  exit 1
+fi
+
+git fetch origin main --tags
+LOCAL="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse origin/main)"
+if [ "$LOCAL" != "$REMOTE" ]; then
+  echo "error: local main ($LOCAL) is not at origin/main ($REMOTE); pull or push first" >&2
+  exit 1
+fi
+
+# Verify locally before cutting anything.
+echo "==> Running verify"
+npm run verify
+
+# `npm version` updates package.json + package-lock.json, commits, and tags.
+echo "==> Bumping version ($BUMP)"
+NEW_VERSION="$(npm version "$BUMP" -m "chore(release): %s")"
+NEW_VERSION="${NEW_VERSION#v}"
+TAG="$NEW_VERSION"
+
+echo "==> Pushing commit and tag $TAG"
+git push origin main
+git push origin "$TAG"
+
+echo "==> Creating GitHub Release $TAG (this triggers the publish workflow)"
+NOTES_FILE="$(mktemp)"
+trap 'rm -f "$NOTES_FILE"' EXIT
+{
+  echo "## Changes"
+  echo
+  PREV_TAG="$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
+  if [ -n "$PREV_TAG" ]; then
+    git log --no-merges --pretty='format:- %s' "$PREV_TAG..$TAG^"
+  else
+    git log --no-merges --pretty='format:- %s' "$TAG^"
+  fi
+  echo
+} > "$NOTES_FILE"
+
+gh release create "$TAG" --title "$TAG" --notes-file "$NOTES_FILE"
+
+echo
+echo "==> Done. $TAG is published."
+echo "    Watch: gh run list --workflow release.yml --limit 1"


### PR DESCRIPTION
## Summary
- Add \`scripts/release/cut-release.sh\` that bumps the version (\`npm version\`), commits, tags, pushes, and creates the GitHub Release in one atomic flow.
- Document the script in \`AGENTS.md\` as the canonical release path.

Releases 1.0.13–1.0.15 silently failed to reach npm because their tags were pushed without a corresponding GitHub Release — and \`release.yml\` only fires on \`release: published\`. This script removes that drift.

## Usage
\`\`\`bash
./scripts/release/cut-release.sh patch    # 1.0.16 → 1.0.17
./scripts/release/cut-release.sh minor    # 1.0.16 → 1.1.0
./scripts/release/cut-release.sh 2.0.0    # explicit
\`\`\`

The script refuses to run if you are not on \`main\`, if your tree is dirty, or if local \`main\` is not at \`origin/main\`. It runs \`npm run verify\` before bumping anything.

## Test plan
- [ ] Dry-run of the safety checks (try from a non-main branch, with a dirty tree, with main behind origin) — each should bail without side effects.
- [ ] Use the script for the next real release once PR A is in.