### PR TITLE
chore: add docs-drift checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,12 @@ Why should we land this now?
 - [ ] Check 2
 - [ ] Check 3
 
+## Documentation impact
+
+- [ ] CLI surface changed (added/removed/renamed a command, flag, or argument) → updated [`feral-file/docs`](https://github.com/feral-file/docs) (`docs/api-reference/cli.md`, and any mentions under `docs/dp1-protocol/`, `docs/llm-agents/`)
+- [ ] Config schema changed → updated `docs/CONFIGURATION.md` and the public docs as needed
+- [ ] No user-facing change — docs updates not required
+
 ## Human Owner
 
 Who owns the task outcome?


### PR DESCRIPTION
## Summary
Add a "Documentation impact" section to the PR template with a checkbox to confirm any CLI-surface change has a matching update in [\`feral-file/docs\`](https://github.com/feral-file/docs).

The \`send\` → \`play\` rename in 1.0.13 / 1.0.14 was not reflected in the public docs for two release cycles — a small process gate prevents that recurring.

## Test plan
- [ ] Open a follow-up PR and confirm the new section appears.