### PR TITLE
refactor(play): extract resolvePlaySource() helper

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,11 @@ import {
 import { buildPlaylist, buildPlaylistDirect } from './src/main';
 import type { Config, Playlist } from './src/types';
 import { discoverFF1Devices } from './src/utilities/ff1-discovery';
-import { isPlaylistSourceUrl, loadPlaylistSource } from './src/utilities/playlist-source';
+import {
+  isPlaylistSourceUrl,
+  loadPlaylistSource,
+  resolvePlaySource,
+} from './src/utilities/playlist-source';
 import { upsertDevice } from './src/utilities/device-upsert';
 import { findExistingDeviceEntry } from './src/utilities/device-lookup';
 import { normalizeDeviceHost, normalizeDeviceIdToHost } from './src/utilities/device-normalize';
@@ -935,63 +939,40 @@ program
   .option('--skip-verify', 'Skip playlist verification before playing')
   .action(async (source: string, options: { device?: string; skipVerify?: boolean }) => {
     try {
-      let playlist: Playlist;
-      let sourceLabel = source;
+      const config = getConfig();
+      const resolved = await resolvePlaySource(source, config.defaultDuration || 10);
+      const isPlaylistSource = resolved.kind === 'playlist';
+      const sourceLabel = isPlaylistSource
+        ? `${resolved.sourceType}: ${resolved.source}`
+        : resolved.source;
 
-      const isUrl = isPlaylistSourceUrl(source);
-      const isFile = !isUrl;
-
-      if (isFile) {
-        console.log(chalk.blue('\nPlay on FF1\n'));
-        const playlistResult = await loadPlaylistSource(source);
-        playlist = playlistResult.playlist;
-        sourceLabel = `${playlistResult.sourceType}: ${playlistResult.source}`;
-      } else {
-        let loadedAsPlaylist = false;
-        try {
-          const playlistResult = await loadPlaylistSource(source);
-          playlist = playlistResult.playlist;
-          sourceLabel = `${playlistResult.sourceType}: ${playlistResult.source}`;
-          loadedAsPlaylist = true;
-        } catch {
-          const config = getConfig();
-          const duration = config.defaultDuration || 10;
-
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const { buildUrlItem, buildDP1Playlist } = require('./src/utilities/playlist-builder');
-
-          const item = buildUrlItem(source, duration);
-          playlist = await buildDP1Playlist({ items: [item], title: item.title });
-        }
-
-        console.log(chalk.blue('\nPlay on FF1\n'));
-
-        if (!loadedAsPlaylist) {
-          sourceLabel = source;
-        }
-      }
+      console.log(chalk.blue('\nPlay on FF1\n'));
 
       if (!options.skipVerify) {
-        if (isFile) {
+        // Synthesized media-URL playlists are trivially valid by construction;
+        // only print the verify lines when the user supplied a real playlist.
+        if (isPlaylistSource) {
           console.log(chalk.cyan(`Verify playlist (${sourceLabel})`));
         }
 
         const verifier = await import('./src/utilities/playlist-verifier');
         const { verifyPlaylist } = verifier;
-        const verifyResult = verifyPlaylist(playlist);
+        const verifyResult = verifyPlaylist(resolved.playlist);
 
         if (!verifyResult.valid) {
           printPlaylistVerificationFailure(
             verifyResult,
-            isFile ? `source: ${sourceLabel}` : undefined
+            isPlaylistSource ? `source: ${sourceLabel}` : undefined
           );
           process.exit(1);
         }
 
-        if (isFile) {
+        if (isPlaylistSource) {
           console.log(chalk.green('✓ Verified\n'));
         }
       }
+
+      const playlist = resolved.playlist;
 
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { sendPlaylistToDevice } = require('./src/utilities/ff1-device');

--- a/src/utilities/playlist-source.ts
+++ b/src/utilities/playlist-source.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from 'fs';
 import type { Playlist } from '../types';
 
+// playlist-builder is still CommonJS; require keeps the interop simple.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { buildUrlItem, buildDP1Playlist } = require('./playlist-builder');
+
 /**
  * Parsed playlist source metadata.
  */
@@ -86,5 +90,81 @@ export async function loadPlaylistSource(source: string): Promise<LoadedPlaylist
     };
   } catch (error) {
     throw new Error(`Invalid JSON in ${trimmedSource}: ${(error as Error).message}`);
+  }
+}
+
+/**
+ * Resolved source for the `play` command.
+ *
+ * `playlist` — the source loaded as a DP-1 playlist (a local file or a
+ *   hosted playlist URL).
+ * `media` — the source is a direct media URL; a single-item DP-1 playlist
+ *   was synthesized around it.
+ *
+ * The kind is what callers branch on to decide whether to print
+ * playlist-style verification messages.
+ */
+export type PlaySource =
+  | {
+      kind: 'playlist';
+      playlist: Playlist;
+      sourceType: 'file' | 'url';
+      source: string;
+    }
+  | {
+      kind: 'media';
+      playlist: Playlist;
+      source: string;
+    };
+
+/**
+ * Resolve a `play` command argument to a playable source.
+ *
+ * Files are always treated as playlists. URLs are tried as playlists first;
+ * if loading fails (network, non-JSON, etc.), the URL is wrapped in a
+ * synthesized single-item playlist so direct media URLs still work.
+ *
+ * The "URL → playlist or media" path uses throw-and-fallback because there
+ * is no cheap way to distinguish a 200-OK media file from a malformed
+ * playlist response without trying to parse it. Keeping the fallback
+ * scoped to one helper means the play action no longer carries the
+ * `loadedAsPlaylist` boolean dance.
+ *
+ * @param source - User-supplied path or URL
+ * @param defaultDuration - Duration (seconds) for the synthesized media item
+ * @returns Resolved playlist + metadata describing how it was loaded
+ * @throws Error When `source` is empty, or is a non-URL file path that cannot be loaded
+ */
+export async function resolvePlaySource(
+  source: string,
+  defaultDuration: number
+): Promise<PlaySource> {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    throw new Error('Playlist source is required');
+  }
+
+  if (!isPlaylistSourceUrl(trimmed)) {
+    const loaded = await loadPlaylistSource(trimmed);
+    return {
+      kind: 'playlist',
+      playlist: loaded.playlist,
+      sourceType: loaded.sourceType,
+      source: loaded.source,
+    };
+  }
+
+  try {
+    const loaded = await loadPlaylistSource(trimmed);
+    return {
+      kind: 'playlist',
+      playlist: loaded.playlist,
+      sourceType: loaded.sourceType,
+      source: loaded.source,
+    };
+  } catch {
+    const item = buildUrlItem(trimmed, defaultDuration);
+    const playlist = (await buildDP1Playlist({ items: [item], title: item.title })) as Playlist;
+    return { kind: 'media', playlist, source: trimmed };
   }
 }

--- a/tests/play-source.test.ts
+++ b/tests/play-source.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { describe, test, before, after } from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolvePlaySource } from '../src/utilities/playlist-source';
+
+const samplePlaylist = {
+  dpVersion: '1.0.0',
+  id: 'test-playlist',
+  title: 'sample',
+  items: [
+    {
+      id: 'item-1',
+      title: 'item one',
+      source: 'https://example.com/a.mp4',
+      duration: 5,
+      license: 'open',
+    },
+  ],
+};
+
+describe('resolvePlaySource', () => {
+  let tmp: string;
+
+  before(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'ff1-play-source-'));
+  });
+
+  after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('rejects an empty source', async () => {
+    await assert.rejects(() => resolvePlaySource('   ', 10), /required/i);
+  });
+
+  test('returns kind=playlist with sourceType=file for a local playlist file', async () => {
+    const path = join(tmp, 'pl.json');
+    writeFileSync(path, JSON.stringify(samplePlaylist), 'utf-8');
+
+    const result = await resolvePlaySource(path, 10);
+    assert.equal(result.kind, 'playlist');
+    if (result.kind === 'playlist') {
+      assert.equal(result.sourceType, 'file');
+      assert.equal(result.source, path);
+      assert.equal(result.playlist.id, 'test-playlist');
+    }
+  });
+
+  test('throws when a non-URL file path cannot be loaded', async () => {
+    await assert.rejects(
+      () => resolvePlaySource(join(tmp, 'does-not-exist.json'), 10),
+      /not found/i
+    );
+  });
+
+  test('returns kind=playlist with sourceType=url for a hosted playlist', async () => {
+    const original = global.fetch;
+    global.fetch = async () =>
+      new Response(JSON.stringify(samplePlaylist), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    try {
+      const result = await resolvePlaySource('https://example.com/playlist.json', 10);
+      assert.equal(result.kind, 'playlist');
+      if (result.kind === 'playlist') {
+        assert.equal(result.sourceType, 'url');
+        assert.equal(result.playlist.id, 'test-playlist');
+      }
+    } finally {
+      global.fetch = original;
+    }
+  });
+
+  test('falls back to kind=media when a URL fails to load as a playlist', async () => {
+    const original = global.fetch;
+    global.fetch = async () =>
+      new Response('binary-bytes', {
+        status: 200,
+        headers: { 'Content-Type': 'video/mp4' },
+      });
+
+    try {
+      const result = await resolvePlaySource('https://example.com/clip.mp4', 7);
+      assert.equal(result.kind, 'media');
+      if (result.kind === 'media') {
+        assert.equal(result.source, 'https://example.com/clip.mp4');
+        assert.equal(result.playlist.items.length, 1);
+        assert.equal(result.playlist.items[0].duration, 7);
+      }
+    } finally {
+      global.fetch = original;
+    }
+  });
+
+  test('falls back to kind=media when a URL returns a non-OK status', async () => {
+    const original = global.fetch;
+    global.fetch = async () => new Response('not found', { status: 404 });
+
+    try {
+      const result = await resolvePlaySource('https://example.com/clip.mp4', 10);
+      assert.equal(result.kind, 'media');
+    } finally {
+      global.fetch = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Extract the file / playlist-URL / media-URL detection in the \`play\` command into \`resolvePlaySource(source, defaultDuration)\`, which returns a discriminated union (\`{ kind: 'playlist', sourceType, ... }\` or \`{ kind: 'media', ... }\`).

The action handler in \`index.ts\` was carrying an \`isUrl\`/\`isFile\` branch, a \`try/catch\` fallback to a synthesized playlist, and a \`loadedAsPlaylist\` boolean used to gate downstream print statements — all interleaved with verification and device send. After the refactor it reads as a flat sequence: **resolve → verify → send**.

## Tests
6 new unit tests in \`tests/play-source.test.ts\` covering:
- empty source rejection
- local playlist file
- file-not-found
- hosted playlist URL (mocked \`fetch\`)
- media-URL fallback when parse fails
- media-URL fallback when fetch returns non-OK

## Behavior change
None. All 140 prior tests still pass. \`smoke\` validation passes.

## Test plan
- [ ] CI green on all platforms.
- [ ] Manual: \`ff1 play playlist.json\`, \`ff1 play https://.../playlist.json\`, \`ff1 play https://.../video.mp4 --skip-verify\` all behave as before.