### PR TITLE
fix(indexer): align NFT indexer GraphQL client with ff-indexer-v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GROK_API_KEY: dummy
-      # Hits production indexer GraphQL in tests/nft-indexer.test.ts (pre-indexed fixture token).
-      FF_INDEXER_INTEGRATION: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GROK_API_KEY: dummy
+      # Hits production indexer GraphQL in tests/nft-indexer.test.ts (pre-indexed fixture token).
+      FF_INDEXER_INTEGRATION: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,16 +137,15 @@ export interface BuildPlaylistResult {
   [key: string]: unknown;
 }
 
-export interface WorkflowStatus {
-  workflow_id: string;
-  run_id: string;
-  status: string;
-  start_time?: string;
-  close_time?: string;
-  execution_time_ms?: number;
+/** Response shape from `triggerTokenIndexing` (ff-indexer GraphQL; job queue). */
+export interface IndexerIndexingTriggerResult {
+  success: boolean;
+  job_id?: number;
+  error?: string;
 }
 
-export interface PollingResult {
+/** Outcome of polling `jobStatus` until terminal state or timeout (nft-indexer client). */
+export interface IndexerJobPollResult {
   success: boolean;
   completed?: boolean;
   timedOut?: boolean;

--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -91,7 +91,7 @@ function buildTokenCID(chain, contractAddress, tokenId) {
 /**
  * Unified GraphQL query for tokens from indexer v2
  *
- * Supports querying by token CIDs and/or owners. Returns tokens with full metadata.
+ * Supports querying by token CIDs and/or owners. Selects `display` and `media_assets` only.
  *
  * @param {Object} params - Query parameters
  * @param {Array<string>} [params.token_cids] - Array of token CIDs to query
@@ -124,48 +124,27 @@ async function queryTokens(params = {}) {
 
   const query = `
       query {
-        tokens(${ownerFilter} ${tokenCidsFilter} ${contractFilter} expands: ["enrichment_source", "metadata_media_asset", "enrichment_source_media_asset"], limit: ${limit}, offset: ${offset}) {
+        tokens(${ownerFilter} ${tokenCidsFilter} ${contractFilter} limit: ${limit}, offset: ${offset}) {
         items {
-          token_cid
-          chain
-          standard
           contract_address
           token_number
           current_owner
           burned
-          metadata {
+          display {
             name
             description
             mime_type
             image_url
             animation_url
             artists {
-              did
               name
             }
           }
-          enrichment_source {
-            name
-            description
-            image_url
-            animation_url
-            artists {
-              did
-              name
-            }
-          }
-          metadata_media_assets {
+          media_assets {
             source_url
-            mime_type
-            variant_urls
-          }
-          enrichment_source_media_assets {
-            source_url
-            mime_type
-            variant_urls
+            variants(keys: [l, m, xl, xxl, preview])
           }
         }
-        total
       }
     }
   `;
@@ -265,49 +244,42 @@ function isUsableSourceUrl(url) {
 }
 
 /**
- * Get best media URL from metadata and enrichment source
+ * getBestMediaUrl picks a DP1-usable URL from indexer `display` and `media_assets`.
  *
- * Prioritizes: enrichment_source.animation_url > metadata.animation_url > media_assets.source_url > image_url
+ * Order: display.animation_url, transcoded asset URLs (source + variants), display.image_url.
  *
- * @param {Object} metadata - Token metadata object
- * @param {Object} enrichmentSource - Token enrichment_source object
- * @param {Array} metadataMediaAssets - Token metadata media assets array
- * @param {Array} enrichmentMediaAssets - Token enrichment source media assets array
+ * @param {Object} display - Token `display` field (merged presentation from indexer)
+ * @param {Array<Object>} mediaAssets - Token `media_assets` rows
  * @returns {Object} Object with url and thumbnail properties
  */
-function getBestMediaUrl(
-  metadata = {},
-  enrichmentSource = {},
-  metadataMediaAssets = [],
-  enrichmentMediaAssets = []
-) {
-  // Priority: animation_url > media assets > image_url
-  // Choose the first candidate that can be represented in DP1 source.
-  const candidates = [
-    enrichmentSource?.animation_url,
-    metadata?.animation_url,
-    ...(Array.isArray(enrichmentMediaAssets)
-      ? enrichmentMediaAssets.map((asset) => asset?.source_url)
-      : []),
-    ...(Array.isArray(metadataMediaAssets)
-      ? metadataMediaAssets.map((asset) => asset?.source_url)
-      : []),
-    enrichmentSource?.image_url,
-    metadata?.image_url,
-  ];
+function getBestMediaUrl(display = {}, mediaAssets = []) {
+  const urlsFromAssets = [];
+  for (const asset of Array.isArray(mediaAssets) ? mediaAssets : []) {
+    if (asset?.source_url) {
+      urlsFromAssets.push(asset.source_url);
+    }
+    const v = asset?.variants;
+    if (v && typeof v === 'object') {
+      for (const val of Object.values(v)) {
+        if (typeof val === 'string') {
+          urlsFromAssets.push(val);
+        }
+      }
+    }
+  }
+
+  const candidates = [display?.animation_url, ...urlsFromAssets, display?.image_url];
 
   for (const candidate of candidates) {
     if (isUsableSourceUrl(candidate)) {
       return {
         url: candidate,
-        thumbnail: enrichmentSource.image_url || metadata.image_url || '',
+        thumbnail: display.image_url || '',
       };
     }
   }
 
-  // Fallback to static image URL even if unsupported.
-  // Caller will validate and provide a clear reason if unusable.
-  const imageUrl = (enrichmentSource && enrichmentSource.image_url) || metadata.image_url || '';
+  const imageUrl = display.image_url || '';
   return {
     url: imageUrl,
     thumbnail: imageUrl,
@@ -315,12 +287,9 @@ function getBestMediaUrl(
 }
 
 /**
- * Map indexer v2 token data to standard format
+ * Map indexer token row (GraphQL `display` + `media_assets`) to internal standard format.
  *
- * Converts the new GraphQL v2 schema format to internal standard format
- * for compatibility with existing code.
- *
- * @param {Object} indexerData - Data from indexer GraphQL v2 query
+ * @param {Object} indexerData - Token fields from indexer GraphQL
  * @param {string} chain - Blockchain network
  * @returns {Object} Standardized token data
  */
@@ -332,27 +301,12 @@ function mapIndexerDataToStandardFormat(indexerData, chain) {
     };
   }
 
-  // Use metadata first, fallback to enrichment_source for missing fields
-  const metadata = indexerData.metadata || {};
-  const enrichmentSource = indexerData.enrichment_source || {};
-  const metadataMediaAssets = indexerData.metadata_media_assets || [];
-  const enrichmentMediaAssets = indexerData.enrichment_source_media_assets || [];
-
-  // Get best media URLs (prioritizes enrichment_source.animation_url first)
-  const media = getBestMediaUrl(
-    metadata,
-    enrichmentSource,
-    metadataMediaAssets,
-    enrichmentMediaAssets
-  );
-
-  // Extract artist name from array format
-  const artistName =
-    extractArtistName(metadata.artists) || extractArtistName(enrichmentSource.artists) || '';
-
-  // Determine best name and description
-  const name = metadata.name || enrichmentSource.name || `Token #${indexerData.token_number}`;
-  const description = metadata.description || enrichmentSource.description || '';
+  const display = indexerData.display || {};
+  const mediaAssets = indexerData.media_assets || [];
+  const media = getBestMediaUrl(display, mediaAssets);
+  const artistName = extractArtistName(display.artists);
+  const name = display.name || `Token #${indexerData.token_number}`;
+  const description = display.description || '';
 
   return {
     success: true,
@@ -364,10 +318,10 @@ function mapIndexerDataToStandardFormat(indexerData, chain) {
       description,
       image: {
         url: media.url,
-        mimeType: metadata.mime_type || 'image/png',
+        mimeType: display.mime_type || 'image/png',
         thumbnail: media.thumbnail,
       },
-      animation_url: metadata.animation_url || enrichmentSource.animation_url,
+      animation_url: display.animation_url,
       metadata: {
         attributes: [],
         artistName,
@@ -533,8 +487,8 @@ async function getNFTTokenInfo(params) {
  * Get single NFT token information from indexer and return as DP1 item
  *
  * Queries the indexer for token data. If not found, triggers async indexing workflow,
- * polls for completion, and retries token query. Also polls for metadata_media_assets
- * to ensure indexed media is available.
+ * polls for completion, and retries token query. Also polls for `media_assets`
+ * while renditions are still processing when needed.
  *
  * @param {Object} params - Token parameters
  * @param {string} params.chain - Blockchain network
@@ -590,35 +544,31 @@ async function getNFTTokenInfoSingle(params, duration = 10) {
         };
       }
 
-      logger.info('[NFT Indexer] Indexing workflow triggered', {
-        workflow_id: indexResult.workflow_id,
-        run_id: indexResult.run_id,
+      logger.info('[NFT Indexer] Indexing job triggered', {
+        job_id: indexResult.job_id,
       });
 
-      // Poll for workflow completion
-      const pollResult = await pollForWorkflowCompletion(
-        indexResult.workflow_id,
-        indexResult.run_id
-      );
+      // Poll for job completion (queue-backed jobs use job_id / jobStatus)
+      const pollResult = await pollForJobCompletion(indexResult.job_id);
 
       if (!pollResult.success) {
-        logger.error('[NFT Indexer] Workflow polling failed:', pollResult.error);
+        logger.error('[NFT Indexer] Job polling failed:', pollResult.error);
         return {
           success: false,
-          error: `Indexing workflow failed: ${pollResult.error}`,
+          error: `Indexing job failed: ${pollResult.error}`,
         };
       }
 
       if (pollResult.timedOut) {
-        logger.warn('[NFT Indexer] Workflow polling timed out before completion');
+        logger.warn('[NFT Indexer] Job polling timed out before completion');
         return {
           success: false,
           error: `Token indexing timed out. Please try again in a moment.`,
         };
       }
 
-      // Workflow completed, query token again
-      logger.info(`[NFT Indexer] Workflow completed, querying token again...`);
+      // Job completed, query token again
+      logger.info(`[NFT Indexer] Job completed, querying token again...`);
       indexerData = await queryTokenDataFromIndexer(tokenCID);
 
       // If still not found after indexing, consider it invalid
@@ -635,13 +585,10 @@ async function getNFTTokenInfoSingle(params, duration = 10) {
 
     logger.info(`[NFT Indexer] ✓ Token found in database`);
 
-    // If token found but no metadata_media_assets, poll for them
-    if (
-      !Array.isArray(indexerData.metadata_media_assets) ||
-      indexerData.metadata_media_assets.length === 0
-    ) {
-      logger.info('[NFT Indexer] Metadata assets not available, polling...');
-      indexerData = await pollForMetadataAssets(tokenCID);
+    // If token found but no media_assets yet, poll until indexer has renditions or timeout
+    if (!Array.isArray(indexerData.media_assets) || indexerData.media_assets.length === 0) {
+      logger.info('[NFT Indexer] Media assets not available, polling...');
+      indexerData = await pollForMediaAssets(tokenCID);
 
       if (!indexerData) {
         logger.warn('[NFT Indexer] Failed to retrieve token data during metadata polling');
@@ -667,11 +614,7 @@ async function getNFTTokenInfoSingle(params, duration = 10) {
 /**
  * Get NFT token information in batch and return as DP1 items (parallel processing)
  *
- * For tokens not in database:
- * 1. Triggers indexing for all missing tokens in parallel
- * 2. Collects workflow IDs
- * 3. Polls each workflow individually with its own ID
- * 4. Continues with remaining tokens even if some fail
+ * For missing tokens: triggers indexing per token, polls by job_id, then fetches again.
  *
  * @param {Array} tokens - Array of token parameters
  * @param {number} duration - Display duration in seconds
@@ -768,10 +711,9 @@ async function getCollectionInfo(params) {
  * @param {string} chain - Blockchain network
  * @param {string} contractAddress - Contract address (required)
  * @param {string} tokenId - Token ID (required)
- * @returns {Promise<Object>} Result with workflow info
- * @returns {boolean} returns.success - Whether workflow was triggered
- * @returns {string} [returns.workflow_id] - Workflow ID if triggered
- * @returns {string} [returns.run_id] - Run ID if triggered
+ * @returns {Promise<Object>} Result with job id only (queue correlation)
+ * @returns {boolean} returns.success - Whether indexing job was accepted
+ * @returns {number} [returns.job_id] - Postgres queue job id; use with jobStatus / pollForJobCompletion
  * @returns {string} [returns.error] - Error message if failed
  */
 async function triggerIndexingAsync(chain, contractAddress, tokenId) {
@@ -779,15 +721,14 @@ async function triggerIndexingAsync(chain, contractAddress, tokenId) {
     // Build token CID
     const tokenCID = buildTokenCID(chain, contractAddress, tokenId);
 
-    logger.debug('[NFT Indexer] Triggering async indexing workflow via GraphQL mutation:', {
+    logger.debug('[NFT Indexer] Triggering token indexing job via GraphQL mutation:', {
       tokenCID,
     });
 
     const mutation = `
       mutation TriggerTokenIndexing($token_cids: [String!]!) {
         triggerTokenIndexing(token_cids: $token_cids) {
-          workflow_id
-          run_id
+          job_id
         }
       }
     `;
@@ -815,20 +756,26 @@ async function triggerIndexingAsync(chain, contractAddress, tokenId) {
     }
 
     const triggerResult = result.data?.triggerTokenIndexing;
-    if (triggerResult?.workflow_id) {
-      logger.debug('[NFT Indexer] ✓ Async indexing workflow started:', triggerResult);
+    const rawJobId = triggerResult?.job_id;
+    const jobId =
+      rawJobId !== undefined && rawJobId !== null && rawJobId !== ''
+        ? typeof rawJobId === 'number'
+          ? rawJobId
+          : parseInt(String(rawJobId), 10)
+        : NaN;
+
+    if (Number.isFinite(jobId) && jobId >= 1) {
+      logger.debug('[NFT Indexer] ✓ Indexing job enqueued:', { jobId });
       return {
         success: true,
-        workflow_id: triggerResult.workflow_id,
-        run_id: triggerResult.run_id,
-      };
-    } else {
-      logger.warn('[NFT Indexer] Unexpected mutation response:', result);
-      return {
-        success: false,
-        error: 'No workflow ID returned',
+        job_id: jobId,
       };
     }
+    logger.warn('[NFT Indexer] Unexpected mutation response:', result);
+    return {
+      success: false,
+      error: 'No job_id returned from triggerTokenIndexing',
+    };
   } catch (error) {
     logger.error('[NFT Indexer] Async indexing error:', error.message);
     return {
@@ -839,38 +786,28 @@ async function triggerIndexingAsync(chain, contractAddress, tokenId) {
 }
 
 /**
- * Query workflow status from indexer
+ * queryJobStatus loads `jobStatus` from the indexer (minimal selection: status + last_error).
  *
- * Checks the status of an async indexing workflow to determine if it has completed.
- *
- * @param {string} workflowId - Workflow ID returned from triggerIndexing
- * @param {string} runId - Run ID returned from triggerIndexing
- * @returns {Promise<Object>} Status result
- * @returns {boolean} returns.success - Whether query succeeded
- * @returns {string} [returns.status] - Workflow status (running, completed, failed)
- * @returns {Object} [returns.workflowData] - Full workflow data
- * @returns {string} [returns.error] - Error message if failed
+ * @param {number|string} jobId - Queue job id from triggerTokenIndexing
+ * @returns {Promise<{ success: boolean, status?: string, lastError?: string|null, error?: string }>}
  */
-async function queryWorkflowStatus(workflowId, runId) {
+async function queryJobStatus(jobId) {
   try {
+    const id = typeof jobId === 'number' ? jobId : parseInt(String(jobId).trim(), 10);
+    if (!Number.isFinite(id) || id < 1) {
+      return { success: false, error: 'Invalid job_id' };
+    }
+
     const query = `
-      query WorkflowStatus($workflow_id: String!, $run_id: String!) {
-        workflowStatus(workflow_id: $workflow_id, run_id: $run_id) {
-          workflow_id
-          run_id
+      query JobStatus($job_id: Int!) {
+        jobStatus(job_id: $job_id) {
           status
-          start_time
-          close_time
-          execution_time_ms
+          last_error
         }
       }
     `;
 
-    const variables = {
-      workflow_id: workflowId,
-      run_id: runId,
-    };
-
+    const variables = { job_id: id };
     const headers = { 'Content-Type': 'application/json' };
 
     const response = await fetch(GRAPHQL_ENDPOINT, {
@@ -889,21 +826,20 @@ async function queryWorkflowStatus(workflowId, runId) {
       throw new Error(`GraphQL errors: ${result.errors.map((e) => e.message).join(', ')}`);
     }
 
-    const workflowData = result.data?.workflowStatus;
-    if (workflowData) {
+    const jobData = result.data?.jobStatus;
+    if (jobData) {
       return {
         success: true,
-        status: workflowData.status,
-        workflowData,
-      };
-    } else {
-      return {
-        success: false,
-        error: 'No workflow data returned',
+        status: jobData.status,
+        lastError: jobData.last_error ?? null,
       };
     }
+    return {
+      success: false,
+      error: 'No job status returned',
+    };
   } catch (error) {
-    logger.error('[NFT Indexer] Failed to query workflow status:', error.message);
+    logger.error('[NFT Indexer] Failed to query job status:', error.message);
     return {
       success: false,
       error: error.message,
@@ -912,33 +848,23 @@ async function queryWorkflowStatus(workflowId, runId) {
 }
 
 /**
- * Poll for workflow completion with configurable interval and timeout
+ * Poll until jobStatus reports a terminal state or timeout.
  *
- * Continuously checks workflow status until completion or timeout.
- *
- * @param {string} workflowId - Workflow ID
- * @param {string} runId - Run ID
- * @returns {Promise<Object>} Polling result
- * @returns {boolean} returns.success - Whether polling succeeded
- * @returns {boolean} returns.completed - Whether workflow completed
- * @returns {boolean} returns.timedOut - Whether polling timed out
- * @returns {string} [returns.status] - Final workflow status
- * @returns {string} [returns.error] - Error message if failed
+ * @param {number|string} jobId - Job id from triggerTokenIndexing
  */
-async function pollForWorkflowCompletion(workflowId, runId) {
+async function pollForJobCompletion(jobId) {
   const startTime = Date.now();
   let pollCount = 0;
 
-  logger.debug('[NFT Indexer] Starting workflow polling...', {
-    workflowId,
-    runId,
+  logger.debug('[NFT Indexer] Starting job polling...', {
+    jobId,
     timeoutMs: POLLING_TIMEOUT_MS,
     intervalMs: POLLING_INTERVAL_MS,
   });
 
   try {
     while (true) {
-      const statusResult = await queryWorkflowStatus(workflowId, runId);
+      const statusResult = await queryJobStatus(jobId);
 
       if (!statusResult.success) {
         return {
@@ -952,10 +878,11 @@ async function pollForWorkflowCompletion(workflowId, runId) {
 
       logger.debug(`[NFT Indexer] Poll #${pollCount}: status = ${status}`);
 
-      // Check if workflow has completed (case-insensitive)
-      if (status.toLowerCase() === 'completed') {
+      const normalized = typeof status === 'string' ? status.toLowerCase() : '';
+
+      if (normalized === 'completed') {
         const elapsedMs = Date.now() - startTime;
-        logger.info(`[NFT Indexer] ✓ Workflow completed after ${pollCount} polls (${elapsedMs}ms)`);
+        logger.info(`[NFT Indexer] ✓ Job completed after ${pollCount} polls (${elapsedMs}ms)`);
         return {
           success: true,
           completed: true,
@@ -964,22 +891,23 @@ async function pollForWorkflowCompletion(workflowId, runId) {
         };
       }
 
-      // Check if workflow failed (case-insensitive)
-      if (status.toLowerCase() === 'failed') {
-        logger.warn('[NFT Indexer] Workflow failed');
+      if (normalized === 'failed') {
+        const detail = statusResult.lastError ? `: ${statusResult.lastError}` : '';
+        logger.warn(`[NFT Indexer] Job failed${detail}`);
         return {
           success: false,
           completed: false,
           timedOut: false,
           status,
-          error: 'Workflow failed',
+          error: `Job failed${detail}`,
         };
       }
 
-      // Check timeout
       const elapsedMs = Date.now() - startTime;
       if (elapsedMs >= POLLING_TIMEOUT_MS) {
-        logger.warn(`[NFT Indexer] Polling timed out after ${pollCount} polls (${elapsedMs}ms)`);
+        logger.warn(
+          `[NFT Indexer] Job polling timed out after ${pollCount} polls (${elapsedMs}ms)`
+        );
         return {
           success: true,
           completed: false,
@@ -988,11 +916,10 @@ async function pollForWorkflowCompletion(workflowId, runId) {
         };
       }
 
-      // Wait before next poll
       await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL_MS));
     }
   } catch (error) {
-    logger.error('[NFT Indexer] Error during workflow polling:', error.message);
+    logger.error('[NFT Indexer] Error during job polling:', error.message);
     return {
       success: false,
       error: error.message,
@@ -1001,14 +928,12 @@ async function pollForWorkflowCompletion(workflowId, runId) {
 }
 
 /**
- * Poll for metadata assets to appear on a token
- *
- * Continuously queries token until metadata_media_assets appears or timeout.
+ * Poll until token has `media_assets` from the indexer (renditions) or timeout.
  *
  * @param {string} tokenCID - Token CID in CAIP-2 format
  * @returns {Promise<Object|null>} Token data when assets appear, null if timeout
  */
-async function pollForMetadataAssets(tokenCID) {
+async function pollForMediaAssets(tokenCID) {
   const startTime = Date.now();
   let pollCount = 0;
 
@@ -1024,26 +949,20 @@ async function pollForMetadataAssets(tokenCID) {
 
       pollCount += 1;
 
-      // Check if metadata_media_assets exists
-      if (
-        tokenData &&
-        Array.isArray(tokenData.metadata_media_assets) &&
-        tokenData.metadata_media_assets.length > 0
-      ) {
+      // Indexer v2 exposes a single `media_assets` list (not legacy metadata_media_assets).
+      if (tokenData && Array.isArray(tokenData.media_assets) && tokenData.media_assets.length > 0) {
         const elapsedMs = Date.now() - startTime;
-        logger.info(
-          `[NFT Indexer] ✓ Metadata assets found after ${pollCount} polls (${elapsedMs}ms)`
-        );
+        logger.info(`[NFT Indexer] ✓ Media assets found after ${pollCount} polls (${elapsedMs}ms)`);
         return tokenData;
       }
 
-      logger.debug(`[NFT Indexer] Poll #${pollCount}: metadata_media_assets not yet available`);
+      logger.debug(`[NFT Indexer] Poll #${pollCount}: media_assets not yet available`);
 
       // Check timeout
       const elapsedMs = Date.now() - startTime;
       if (elapsedMs >= POLLING_TIMEOUT_MS) {
         logger.warn(
-          `[NFT Indexer] Metadata assets polling timed out after ${pollCount} polls (${elapsedMs}ms). Using fallback URLs.`
+          `[NFT Indexer] Media assets polling timed out after ${pollCount} polls (${elapsedMs}ms). Using fallback URLs.`
         );
         return tokenData; // Return token data as-is, will use fallback URLs
       }
@@ -1052,7 +971,7 @@ async function pollForMetadataAssets(tokenCID) {
       await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL_MS));
     }
   } catch (error) {
-    logger.error('[NFT Indexer] Error during metadata assets polling:', error.message);
+    logger.error('[NFT Indexer] Error during media assets polling:', error.message);
     return null;
   }
 }
@@ -1186,10 +1105,10 @@ module.exports = {
   queryTokensByContract,
   // Unified GraphQL query
   queryTokens,
-  // Workflow and polling functions
-  queryWorkflowStatus,
-  pollForWorkflowCompletion,
-  pollForMetadataAssets,
+  // Job queue
+  queryJobStatus,
+  pollForJobCompletion,
+  pollForMetadataAssets: pollForMediaAssets,
   // Export for testing
   queryTokenDataFromIndexer,
   mapIndexerDataToStandardFormat,

--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -4,7 +4,7 @@
  * to retrieve comprehensive token information.
  */
 
-const GRAPHQL_ENDPOINT = 'https://indexer-v2.feralfile.com/graphql';
+const GRAPHQL_ENDPOINT = 'https://indexer.feralfile.com/graphql';
 const logger = require('../logger');
 
 // Polling configuration (in milliseconds)

--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -12,6 +12,81 @@ const POLLING_INTERVAL_MS = 2000; // Poll every 2 seconds
 const POLLING_TIMEOUT_MS = 60000; // Max poll for 1 minute
 
 /**
+ * GraphQL mutation document for enqueueing token indexing (exposed for tests; must match runtime).
+ */
+const TRIGGER_TOKEN_INDEXING_MUTATION = `
+      mutation TriggerTokenIndexing($token_cids: [String!]!) {
+        triggerTokenIndexing(token_cids: $token_cids) {
+          job_id
+        }
+      }
+    `;
+
+/**
+ * GraphQL query document for job queue status (exposed for tests; must match runtime).
+ */
+const JOB_STATUS_QUERY = `
+      query JobStatus($job_id: Int!) {
+        jobStatus(job_id: $job_id) {
+          status
+          last_error
+        }
+      }
+    `;
+
+/**
+ * buildTokensListQuery builds the `tokens { items { ... } }` request body used by queryTokens.
+ *
+ * Selection uses only `display` and `media_assets`. The indexer merges metadata and enrichment
+ * into `display`; the client does not repeat that merge by fetching raw metadata fields.
+ *
+ * @param {Object} [params]
+ * @param {Array<string>} [params.token_cids]
+ * @param {Array<string>} [params.owners]
+ * @param {Array<string>} [params.contract_addresses]
+ * @param {number} [params.limit]
+ * @param {number} [params.offset]
+ * @returns {string} GraphQL query string (inline arguments, no variables)
+ */
+function buildTokensListQuery(params = {}) {
+  const { token_cids = [], owners = [], contract_addresses = [], limit = 50, offset = 0 } = params;
+
+  const ownerFilter = owners.length > 0 ? `owners: ${JSON.stringify(owners)},` : '';
+  const tokenCidsFilter = token_cids.length > 0 ? `token_cids: ${JSON.stringify(token_cids)},` : '';
+  const contractFilter =
+    contract_addresses.length > 0
+      ? `contract_addresses: ${JSON.stringify(contract_addresses)},`
+      : '';
+
+  return `
+      query {
+        tokens(${ownerFilter} ${tokenCidsFilter} ${contractFilter} limit: ${limit}, offset: ${offset}) {
+        items {
+          contract_address
+          token_number
+          current_owner
+          burned
+          display {
+            name
+            description
+            mime_type
+            image_url
+            animation_url
+            artists {
+              name
+            }
+          }
+          media_assets {
+            source_url
+            variants(keys: [l, m, xl, xxl, preview])
+          }
+        }
+      }
+    }
+  `;
+}
+
+/**
  * Initialize indexer (no-op for compatibility)
  *
  * The indexer endpoint is now hardcoded to the Feral File production endpoint.
@@ -111,43 +186,8 @@ function buildTokenCID(chain, contractAddress, tokenId) {
  * const tokens = await queryTokens({ token_cids: ['eip155:1:erc721:0xabc:123'], owners: ['0x1234...'] });
  */
 async function queryTokens(params = {}) {
-  const { token_cids = [], owners = [], contract_addresses = [], limit = 50, offset = 0 } = params;
-
-  // Build GraphQL query without variables - inline parameters
-  // (API expects inline parameters, not variables)
-  const ownerFilter = owners.length > 0 ? `owners: ${JSON.stringify(owners)},` : '';
-  const tokenCidsFilter = token_cids.length > 0 ? `token_cids: ${JSON.stringify(token_cids)},` : '';
-  const contractFilter =
-    contract_addresses.length > 0
-      ? `contract_addresses: ${JSON.stringify(contract_addresses)},`
-      : '';
-
-  const query = `
-      query {
-        tokens(${ownerFilter} ${tokenCidsFilter} ${contractFilter} limit: ${limit}, offset: ${offset}) {
-        items {
-          contract_address
-          token_number
-          current_owner
-          burned
-          display {
-            name
-            description
-            mime_type
-            image_url
-            animation_url
-            artists {
-              name
-            }
-          }
-          media_assets {
-            source_url
-            variants(keys: [l, m, xl, xxl, preview])
-          }
-        }
-      }
-    }
-  `;
+  const { token_cids = [], owners = [], limit = 50, offset = 0 } = params;
+  const query = buildTokensListQuery(params);
 
   try {
     const headers = { 'Content-Type': 'application/json' };
@@ -288,6 +328,10 @@ function getBestMediaUrl(display = {}, mediaAssets = []) {
 
 /**
  * Map indexer token row (GraphQL `display` + `media_assets`) to internal standard format.
+ *
+ * Treats `display` as the authoritative merged presentation from the server. When `display`
+ * is null or partial, we only use what is present (for example `Token #${token_number}` for name);
+ * we do not splice in raw `metadata` or enrichment because those are not selected from GraphQL.
  *
  * @param {Object} indexerData - Token fields from indexer GraphQL
  * @param {string} chain - Blockchain network
@@ -495,9 +539,12 @@ async function getNFTTokenInfo(params) {
  * @param {string} params.contractAddress - Contract address
  * @param {string} params.tokenId - Token ID
  * @param {number} duration - Display duration in seconds
+ * @param {Object} [options] - Optional overrides (for tests): polling intervals/timeouts
+ * @param {Object} [options.jobPoll] - Passed to pollForJobCompletion
+ * @param {Object} [options.mediaPoll] - Passed to pollForMediaAssets
  * @returns {Promise<Object>} DP1 item with success/error status
  */
-async function getNFTTokenInfoSingle(params, duration = 10) {
+async function getNFTTokenInfoSingle(params, duration = 10, options = {}) {
   let chain = params.chain;
   const { contractAddress, tokenId } = params;
 
@@ -549,7 +596,7 @@ async function getNFTTokenInfoSingle(params, duration = 10) {
       });
 
       // Poll for job completion (queue-backed jobs use job_id / jobStatus)
-      const pollResult = await pollForJobCompletion(indexResult.job_id);
+      const pollResult = await pollForJobCompletion(indexResult.job_id, options.jobPoll ?? {});
 
       if (!pollResult.success) {
         logger.error('[NFT Indexer] Job polling failed:', pollResult.error);
@@ -588,7 +635,7 @@ async function getNFTTokenInfoSingle(params, duration = 10) {
     // If token found but no media_assets yet, poll until indexer has renditions or timeout
     if (!Array.isArray(indexerData.media_assets) || indexerData.media_assets.length === 0) {
       logger.info('[NFT Indexer] Media assets not available, polling...');
-      indexerData = await pollForMediaAssets(tokenCID);
+      indexerData = await pollForMediaAssets(tokenCID, options.mediaPoll ?? {});
 
       if (!indexerData) {
         logger.warn('[NFT Indexer] Failed to retrieve token data during metadata polling');
@@ -725,13 +772,7 @@ async function triggerIndexingAsync(chain, contractAddress, tokenId) {
       tokenCID,
     });
 
-    const mutation = `
-      mutation TriggerTokenIndexing($token_cids: [String!]!) {
-        triggerTokenIndexing(token_cids: $token_cids) {
-          job_id
-        }
-      }
-    `;
+    const mutation = TRIGGER_TOKEN_INDEXING_MUTATION;
 
     const variables = {
       token_cids: [tokenCID],
@@ -798,14 +839,7 @@ async function queryJobStatus(jobId) {
       return { success: false, error: 'Invalid job_id' };
     }
 
-    const query = `
-      query JobStatus($job_id: Int!) {
-        jobStatus(job_id: $job_id) {
-          status
-          last_error
-        }
-      }
-    `;
+    const query = JOB_STATUS_QUERY;
 
     const variables = { job_id: id };
     const headers = { 'Content-Type': 'application/json' };
@@ -851,15 +885,20 @@ async function queryJobStatus(jobId) {
  * Poll until jobStatus reports a terminal state or timeout.
  *
  * @param {number|string} jobId - Job id from triggerTokenIndexing
+ * @param {Object} [options]
+ * @param {number} [options.intervalMs] - Delay between polls (default POLLING_INTERVAL_MS)
+ * @param {number} [options.timeoutMs] - Max wall time (default POLLING_TIMEOUT_MS)
  */
-async function pollForJobCompletion(jobId) {
+async function pollForJobCompletion(jobId, options = {}) {
+  const intervalMs = options.intervalMs ?? POLLING_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? POLLING_TIMEOUT_MS;
   const startTime = Date.now();
   let pollCount = 0;
 
   logger.debug('[NFT Indexer] Starting job polling...', {
     jobId,
-    timeoutMs: POLLING_TIMEOUT_MS,
-    intervalMs: POLLING_INTERVAL_MS,
+    timeoutMs,
+    intervalMs,
   });
 
   try {
@@ -904,7 +943,7 @@ async function pollForJobCompletion(jobId) {
       }
 
       const elapsedMs = Date.now() - startTime;
-      if (elapsedMs >= POLLING_TIMEOUT_MS) {
+      if (elapsedMs >= timeoutMs) {
         logger.warn(
           `[NFT Indexer] Job polling timed out after ${pollCount} polls (${elapsedMs}ms)`
         );
@@ -916,7 +955,7 @@ async function pollForJobCompletion(jobId) {
         };
       }
 
-      await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL_MS));
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
   } catch (error) {
     logger.error('[NFT Indexer] Error during job polling:', error.message);
@@ -931,16 +970,21 @@ async function pollForJobCompletion(jobId) {
  * Poll until token has `media_assets` from the indexer (renditions) or timeout.
  *
  * @param {string} tokenCID - Token CID in CAIP-2 format
+ * @param {Object} [options]
+ * @param {number} [options.intervalMs] - Delay between polls (default POLLING_INTERVAL_MS)
+ * @param {number} [options.timeoutMs] - Max wall time (default POLLING_TIMEOUT_MS)
  * @returns {Promise<Object|null>} Token data when assets appear, null if timeout
  */
-async function pollForMediaAssets(tokenCID) {
+async function pollForMediaAssets(tokenCID, options = {}) {
+  const intervalMs = options.intervalMs ?? POLLING_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? POLLING_TIMEOUT_MS;
   const startTime = Date.now();
   let pollCount = 0;
 
   logger.debug('[NFT Indexer] Starting metadata assets polling...', {
     tokenCID,
-    timeoutMs: POLLING_TIMEOUT_MS,
-    intervalMs: POLLING_INTERVAL_MS,
+    timeoutMs,
+    intervalMs,
   });
 
   try {
@@ -960,7 +1004,7 @@ async function pollForMediaAssets(tokenCID) {
 
       // Check timeout
       const elapsedMs = Date.now() - startTime;
-      if (elapsedMs >= POLLING_TIMEOUT_MS) {
+      if (elapsedMs >= timeoutMs) {
         logger.warn(
           `[NFT Indexer] Media assets polling timed out after ${pollCount} polls (${elapsedMs}ms). Using fallback URLs.`
         );
@@ -968,7 +1012,7 @@ async function pollForMediaAssets(tokenCID) {
       }
 
       // Wait before next poll
-      await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL_MS));
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
   } catch (error) {
     logger.error('[NFT Indexer] Error during media assets polling:', error.message);
@@ -1115,4 +1159,8 @@ module.exports = {
   detectTokenStandard,
   extractArtistName,
   getBestMediaUrl,
+  // GraphQL documents (tests / contract stability)
+  buildTokensListQuery,
+  TRIGGER_TOKEN_INDEXING_MUTATION,
+  JOB_STATUS_QUERY,
 };

--- a/tests/nft-indexer.test.ts
+++ b/tests/nft-indexer.test.ts
@@ -20,6 +20,36 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
   } as Response;
 }
 
+/** Parses POST body from fetch(init) in nft-indexer tests. */
+function graphqlRequestFromInit(init?: RequestInit): { query: string; variables?: unknown } {
+  const raw = init?.body;
+  const text =
+    typeof raw === 'string' ? raw : raw !== undefined && raw !== null ? String(raw) : '{}';
+  const parsed = JSON.parse(text) as { query?: string; variables?: unknown };
+  assert.ok(typeof parsed.query === 'string', 'expected GraphQL query string in fetch body');
+  return { query: parsed.query, variables: parsed.variables };
+}
+
+/** Minimal token row matching indexer `tokens.items` shape used by mocks. */
+function mockTokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    contract_address: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+    token_number: '7804',
+    current_owner: '0x1111111111111111111111111111111111111111',
+    burned: false,
+    display: {
+      name: 'Punk 7804',
+      description: 'Mock',
+      mime_type: 'image/png',
+      image_url: 'https://example.com/punk.png',
+      animation_url: '',
+      artists: [{ name: 'Larva Labs' }],
+    },
+    media_assets: [{ source_url: 'https://cdn.example.com/punk.png', variants: {} }],
+    ...overrides,
+  };
+}
+
 test('getBestMediaUrl: display.animation_url takes precedence', () => {
   const { getBestMediaUrl } = nftIndexer;
   const media = getBestMediaUrl(
@@ -325,3 +355,225 @@ test('triggerIndexingAsync: returns error when no job_id in response', async () 
     global.fetch = originalFetch;
   }
 });
+
+// ——— GraphQL document shape (regression guard for ff-indexer-v2 contract) ———
+
+test('GraphQL documents: tokens list selects display + media_assets variants only', () => {
+  const { buildTokensListQuery } = nftIndexer;
+  const q = buildTokensListQuery({
+    token_cids: ['eip155:1:erc721:0xabc:1'],
+    limit: 10,
+    offset: 2,
+  });
+  assert.match(q, /tokens\s*\(\s*token_cids:/);
+  assert.match(q, /display\s*\{/);
+  assert.match(q, /\bname\b/);
+  assert.match(q, /\bdescription\b/);
+  assert.match(q, /\bmime_type\b/);
+  assert.match(q, /\bimage_url\b/);
+  assert.match(q, /\banimation_url\b/);
+  assert.match(q, /artists\s*\{\s*name\s*\}/);
+  assert.match(q, /media_assets\s*\{/);
+  assert.match(q, /variants\s*\(\s*keys:\s*\[\s*l,\s*m,\s*xl,\s*xxl,\s*preview\s*]\s*\)/);
+  assert.match(q, /\blimit:\s*10\b/);
+  assert.match(q, /\boffset:\s*2\b/);
+  assert.doesNotMatch(q, /\benrichment_source\b/);
+  assert.doesNotMatch(q, /\bmetadata\s*\{/);
+});
+
+test('GraphQL documents: triggerTokenIndexing mutation shape', () => {
+  const { TRIGGER_TOKEN_INDEXING_MUTATION } = nftIndexer;
+  assert.match(TRIGGER_TOKEN_INDEXING_MUTATION, /mutation\s+TriggerTokenIndexing/);
+  assert.match(TRIGGER_TOKEN_INDEXING_MUTATION, /\$token_cids:\s*\[String!\]!/);
+  assert.match(
+    TRIGGER_TOKEN_INDEXING_MUTATION,
+    /triggerTokenIndexing\s*\(\s*token_cids:\s*\$token_cids\s*\)/
+  );
+  assert.match(TRIGGER_TOKEN_INDEXING_MUTATION, /job_id/);
+});
+
+test('GraphQL documents: jobStatus query shape', () => {
+  const { JOB_STATUS_QUERY } = nftIndexer;
+  assert.match(JOB_STATUS_QUERY, /query\s+JobStatus/);
+  assert.match(JOB_STATUS_QUERY, /\$job_id:\s*Int!/);
+  assert.match(JOB_STATUS_QUERY, /jobStatus\s*\(\s*job_id:\s*\$job_id\s*\)/);
+  assert.match(JOB_STATUS_QUERY, /\bstatus\b/);
+  assert.match(JOB_STATUS_QUERY, /\blast_error\b/);
+});
+
+// ——— getNFTTokenInfoSingle ———
+
+test('getNFTTokenInfoSingle: mock single tokens response (already indexed)', async () => {
+  const { getNFTTokenInfoSingle } = nftIndexer;
+  const originalFetch = global.fetch;
+  const row = mockTokenRow();
+
+  global.fetch = async (_url: string, init?: RequestInit) => {
+    const { query } = graphqlRequestFromInit(init);
+    assert.ok(query.includes('tokens('), 'expected tokens query');
+    return jsonResponse({
+      data: {
+        tokens: { items: [row], total: 1 },
+      },
+    });
+  };
+
+  try {
+    const result = await getNFTTokenInfoSingle(
+      {
+        chain: 'ethereum',
+        contractAddress: row.contract_address as string,
+        tokenId: row.token_number as string,
+      },
+      10,
+      { jobPoll: { intervalMs: 0 }, mediaPoll: { intervalMs: 0 } }
+    );
+    assert.equal(result.success, true);
+    if (!result.success || !('item' in result) || !result.item) {
+      assert.fail('expected DP1 item');
+    }
+    assert.equal(result.item.source, 'https://cdn.example.com/punk.png');
+    assert.equal(result.item.title, 'Punk 7804');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('getNFTTokenInfoSingle: mock miss then trigger, job completed, then token with media', async () => {
+  const { getNFTTokenInfoSingle } = nftIndexer;
+  const originalFetch = global.fetch;
+  let tokenRound = 0;
+
+  global.fetch = async (_url: string, init?: RequestInit) => {
+    const { query } = graphqlRequestFromInit(init);
+    if (query.includes('triggerTokenIndexing')) {
+      return jsonResponse({
+        data: { triggerTokenIndexing: { job_id: 42 } },
+      });
+    }
+    if (query.includes('jobStatus')) {
+      return jsonResponse({
+        data: { jobStatus: { status: 'completed', last_error: null } },
+      });
+    }
+    if (query.includes('tokens(')) {
+      tokenRound += 1;
+      if (tokenRound === 1) {
+        return jsonResponse({ data: { tokens: { items: [], total: 0 } } });
+      }
+      return jsonResponse({
+        data: {
+          tokens: { items: [mockTokenRow()], total: 1 },
+        },
+      });
+    }
+    assert.fail(`unexpected fetch query: ${query.slice(0, 80)}`);
+  };
+
+  try {
+    const row = mockTokenRow();
+    const result = await getNFTTokenInfoSingle(
+      {
+        chain: 'ethereum',
+        contractAddress: row.contract_address as string,
+        tokenId: row.token_number as string,
+      },
+      10,
+      { jobPoll: { intervalMs: 0 }, mediaPoll: { intervalMs: 0 } }
+    );
+    assert.equal(result.success, true);
+    if (!result.success || !('item' in result) || !result.item) {
+      assert.fail('expected DP1 item');
+    }
+    assert.ok(result.item.source);
+    assert.equal(tokenRound, 2);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('getNFTTokenInfoSingle: mock polls media_assets when first hit has empty list', async () => {
+  const { getNFTTokenInfoSingle } = nftIndexer;
+  const originalFetch = global.fetch;
+  let tokenCalls = 0;
+
+  global.fetch = async (_url: string, init?: RequestInit) => {
+    const { query } = graphqlRequestFromInit(init);
+    if (query.includes('tokens(')) {
+      tokenCalls += 1;
+      if (tokenCalls === 1) {
+        return jsonResponse({
+          data: {
+            tokens: {
+              items: [
+                mockTokenRow({
+                  media_assets: [],
+                  display: {
+                    name: 'Pending',
+                    description: '',
+                    mime_type: 'video/mp4',
+                    image_url: '',
+                    animation_url: '',
+                    artists: [],
+                  },
+                }),
+              ],
+              total: 1,
+            },
+          },
+        });
+      }
+      return jsonResponse({
+        data: {
+          tokens: {
+            items: [mockTokenRow()],
+            total: 1,
+          },
+        },
+      });
+    }
+    assert.fail('expected only tokens queries in this scenario');
+  };
+
+  try {
+    const row = mockTokenRow();
+    const result = await getNFTTokenInfoSingle(
+      {
+        chain: 'ethereum',
+        contractAddress: row.contract_address as string,
+        tokenId: row.token_number as string,
+      },
+      10,
+      { jobPoll: { intervalMs: 0 }, mediaPoll: { intervalMs: 0 } }
+    );
+    assert.equal(result.success, true);
+    assert.equal(tokenCalls, 2);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test(
+  'getNFTTokenInfoSingle: integration when FF_INDEXER_INTEGRATION=1 (pre-indexed token only)',
+  { skip: process.env.FF_INDEXER_INTEGRATION !== '1' },
+  async (t) => {
+    const { getNFTTokenInfoSingle, queryTokens, buildTokenCID } = nftIndexer;
+    const chain = 'ethereum';
+    const contractAddress = '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb';
+    const tokenId = '7804';
+    const tokenCID = String(buildTokenCID(chain, contractAddress, tokenId));
+
+    const existing = await queryTokens({ token_cids: [tokenCID], limit: 1 });
+    if (!Array.isArray(existing) || existing.length === 0) {
+      t.skip('Token not present in indexer yet; skipping to avoid async chain jobs in integration');
+      return;
+    }
+
+    const result = await getNFTTokenInfoSingle({ chain, contractAddress, tokenId }, 10);
+    assert.equal(result.success, true, JSON.stringify(result));
+    if (!result.success || !('item' in result)) {
+      assert.fail('expected success with item');
+    }
+    assert.ok(result.item?.source && result.item.source.length > 0, 'expected DP1 source URL');
+  }
+);

--- a/tests/nft-indexer.test.ts
+++ b/tests/nft-indexer.test.ts
@@ -552,29 +552,3 @@ test('getNFTTokenInfoSingle: mock polls media_assets when first hit has empty li
     global.fetch = originalFetch;
   }
 });
-
-test(
-  'getNFTTokenInfoSingle: integration when FF_INDEXER_INTEGRATION=1 (pre-indexed token only)',
-  { skip: process.env.FF_INDEXER_INTEGRATION !== '1' },
-  async (t) => {
-    const { getNFTTokenInfoSingle, queryTokens, buildTokenCID } = nftIndexer;
-    const chain = 'ethereum';
-    // Fixture must exist on https://indexer.feralfile.com (verified via tokens query by contract).
-    const contractAddress = '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270';
-    const tokenId = '52000296';
-    const tokenCID = String(buildTokenCID(chain, contractAddress, tokenId));
-
-    const existing = await queryTokens({ token_cids: [tokenCID], limit: 1 });
-    if (!Array.isArray(existing) || existing.length === 0) {
-      t.skip('Token not present in indexer yet; skipping to avoid async chain jobs in integration');
-      return;
-    }
-
-    const result = await getNFTTokenInfoSingle({ chain, contractAddress, tokenId }, 10);
-    assert.equal(result.success, true, JSON.stringify(result));
-    if (!result.success || !('item' in result)) {
-      assert.fail('expected success with item');
-    }
-    assert.ok(result.item?.source && result.item.source.length > 0, 'expected DP1 source URL');
-  }
-);

--- a/tests/nft-indexer.test.ts
+++ b/tests/nft-indexer.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Ensures nft-indexer media and mapping logic matches ff-indexer-v2 GraphQL:
+ * `display` + unified `media_assets`, and job-based status.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const nftIndexer = require('../src/utilities/nft-indexer');
+
+/**
+ * Minimal `Response` stub for tests. `nft-indexer` only reads `ok`, `status`, and `json()`.
+ */
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+test('getBestMediaUrl: display.animation_url takes precedence', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const media = getBestMediaUrl(
+    {
+      animation_url: 'https://example.com/animation.mp4',
+      image_url: 'https://example.com/image.png',
+    },
+    [{ source_url: 'https://cdn.example/fallback.mp4', variants: {} }]
+  );
+  assert.equal(media.url, 'https://example.com/animation.mp4');
+  assert.equal(media.thumbnail, 'https://example.com/image.png');
+});
+
+test('getBestMediaUrl: falls back to media asset source_url when no animation_url', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const media = getBestMediaUrl({ animation_url: '', image_url: 'https://example.com/image.png' }, [
+    { source_url: 'https://cdn.example/file.mp4', variants: {} },
+  ]);
+  assert.equal(media.url, 'https://cdn.example/file.mp4');
+});
+
+test('getBestMediaUrl: uses variant URLs from media_assets', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const media = getBestMediaUrl({ animation_url: '', image_url: '' }, [
+    {
+      source_url: '',
+      variants: { l: 'https://cdn.example/transcoded.mp4' },
+    },
+  ]);
+  assert.equal(media.url, 'https://cdn.example/transcoded.mp4');
+});
+
+test('getBestMediaUrl: falls back to display.image_url when no media assets', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const media = getBestMediaUrl(
+    { animation_url: '', image_url: 'https://example.com/image.png' },
+    []
+  );
+  assert.equal(media.url, 'https://example.com/image.png');
+  assert.equal(media.thumbnail, 'https://example.com/image.png');
+});
+
+test('getBestMediaUrl: handles null/empty display and media_assets', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const media = getBestMediaUrl({}, []);
+  assert.equal(media.url, '');
+  assert.equal(media.thumbnail, '');
+});
+
+test('getBestMediaUrl: skips data URIs', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const media = getBestMediaUrl(
+    {
+      animation_url: 'data:image/png;base64,abc123',
+      image_url: 'https://example.com/fallback.png',
+    },
+    []
+  );
+  assert.equal(media.url, 'https://example.com/fallback.png');
+});
+
+test('getBestMediaUrl: skips URLs longer than 1024 chars', () => {
+  const { getBestMediaUrl } = nftIndexer;
+  const longUrl = 'https://example.com/' + 'x'.repeat(1100);
+  const media = getBestMediaUrl(
+    { animation_url: longUrl, image_url: 'https://example.com/fallback.png' },
+    []
+  );
+  assert.equal(media.url, 'https://example.com/fallback.png');
+});
+
+test('mapIndexerDataToStandardFormat: reads display fields', () => {
+  const { mapIndexerDataToStandardFormat } = nftIndexer;
+  const out = mapIndexerDataToStandardFormat(
+    {
+      token_number: '1',
+      contract_address: '0xabc',
+      current_owner: '0xowner',
+      burned: false,
+      display: {
+        name: 'Test Token',
+        description: 'Test description',
+        mime_type: 'video/mp4',
+        image_url: 'https://example.com/image.png',
+        animation_url: 'https://example.com/video.mp4',
+        artists: [{ name: 'Artist Name' }],
+      },
+      media_assets: [],
+    },
+    'ethereum'
+  );
+  assert.equal(out.success, true);
+  if (!('token' in out) || !out.token) {
+    assert.fail('expected token on success');
+  }
+  assert.equal(out.token.name, 'Test Token');
+  assert.equal(out.token.description, 'Test description');
+  assert.equal(out.token.animation_url, 'https://example.com/video.mp4');
+  assert.equal(out.token.metadata.artistName, 'Artist Name');
+});
+
+test('mapIndexerDataToStandardFormat: uses media_assets for image URL', () => {
+  const { mapIndexerDataToStandardFormat } = nftIndexer;
+  const out = mapIndexerDataToStandardFormat(
+    {
+      token_number: '1',
+      contract_address: '0xabc',
+      current_owner: '0xowner',
+      burned: false,
+      display: { name: 'Test', mime_type: 'video/mp4' },
+      media_assets: [{ source_url: 'https://cdn.example/file.mp4', variants: {} }],
+    },
+    'ethereum'
+  );
+  assert.equal(out.success, true);
+  if (!('token' in out) || !out.token) {
+    assert.fail('expected token on success');
+  }
+  assert.equal(out.token.image.url, 'https://cdn.example/file.mp4');
+});
+
+test('mapIndexerDataToStandardFormat: handles missing display gracefully', () => {
+  const { mapIndexerDataToStandardFormat } = nftIndexer;
+  const out = mapIndexerDataToStandardFormat(
+    {
+      token_number: '123',
+      contract_address: '0xabc',
+      current_owner: '0xowner',
+      burned: false,
+      media_assets: [],
+    },
+    'ethereum'
+  );
+  assert.equal(out.success, true);
+  if (!('token' in out) || !out.token) {
+    assert.fail('expected token on success');
+  }
+  assert.equal(out.token.name, 'Token #123');
+  assert.equal(out.token.metadata.artistName, '');
+});
+
+test('mapIndexerDataToStandardFormat: returns error for null indexerData', () => {
+  const { mapIndexerDataToStandardFormat } = nftIndexer;
+  const out = mapIndexerDataToStandardFormat(null, 'ethereum');
+  assert.equal(out.success, false);
+  assert.equal(out.error, 'Token not found in indexer');
+});
+
+// Job polling tests using global.fetch stubbing
+
+test('queryJobStatus: returns status and lastError on success', async () => {
+  const { queryJobStatus } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () =>
+    jsonResponse({
+      data: {
+        jobStatus: {
+          status: 'running',
+          last_error: null,
+        },
+      },
+    });
+
+  try {
+    const result = await queryJobStatus(123);
+    assert.equal(result.success, true);
+    assert.equal(result.status, 'running');
+    assert.equal(result.lastError, null);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('queryJobStatus: handles HTTP errors', async () => {
+  const { queryJobStatus } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () => jsonResponse(null, false, 500);
+
+  try {
+    const result = await queryJobStatus(123);
+    assert.equal(result.success, false);
+    assert.ok(result.error?.includes('HTTP error'));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('queryJobStatus: handles GraphQL errors', async () => {
+  const { queryJobStatus } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () =>
+    jsonResponse({
+      errors: [{ message: 'Job not found' }],
+    });
+
+  try {
+    const result = await queryJobStatus(123);
+    assert.equal(result.success, false);
+    assert.ok(result.error?.includes('GraphQL errors'));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('queryJobStatus: rejects invalid job_id', async () => {
+  const { queryJobStatus } = nftIndexer;
+  const result = await queryJobStatus('invalid');
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'Invalid job_id');
+});
+
+test('pollForJobCompletion: completes on "completed" status', async () => {
+  const { pollForJobCompletion } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () =>
+    jsonResponse({
+      data: {
+        jobStatus: {
+          status: 'completed',
+          last_error: null,
+        },
+      },
+    });
+
+  try {
+    const result = await pollForJobCompletion(123);
+    assert.equal(result.success, true);
+    assert.equal(result.completed, true);
+    assert.equal(result.timedOut, false);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('pollForJobCompletion: fails on "failed" status with lastError', async () => {
+  const { pollForJobCompletion } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () =>
+    jsonResponse({
+      data: {
+        jobStatus: {
+          status: 'failed',
+          last_error: 'Token not found',
+        },
+      },
+    });
+
+  try {
+    const result = await pollForJobCompletion(123);
+    assert.equal(result.success, false);
+    assert.equal(result.completed, false);
+    assert.ok(result.error?.includes('Token not found'));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('triggerIndexingAsync: parses job_id from response', async () => {
+  const { triggerIndexingAsync } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () =>
+    jsonResponse({
+      data: {
+        triggerTokenIndexing: {
+          job_id: 456,
+        },
+      },
+    });
+
+  try {
+    const result = await triggerIndexingAsync('ethereum', '0xabc', '123');
+    assert.equal(result.success, true);
+    assert.equal(result.job_id, 456);
+    assert.equal(result.workflow_id, undefined);
+    assert.equal(result.run_id, undefined);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('triggerIndexingAsync: returns error when no job_id in response', async () => {
+  const { triggerIndexingAsync } = nftIndexer;
+  const originalFetch = global.fetch;
+
+  global.fetch = async () =>
+    jsonResponse({
+      data: {
+        triggerTokenIndexing: {},
+      },
+    });
+
+  try {
+    const result = await triggerIndexingAsync('ethereum', '0xabc', '123');
+    assert.equal(result.success, false);
+    assert.ok(result.error?.includes('No job_id'));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/tests/nft-indexer.test.ts
+++ b/tests/nft-indexer.test.ts
@@ -408,7 +408,7 @@ test('getNFTTokenInfoSingle: mock single tokens response (already indexed)', asy
   const originalFetch = global.fetch;
   const row = mockTokenRow();
 
-  global.fetch = async (_url: string, init?: RequestInit) => {
+  global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
     const { query } = graphqlRequestFromInit(init);
     assert.ok(query.includes('tokens('), 'expected tokens query');
     return jsonResponse({
@@ -444,7 +444,7 @@ test('getNFTTokenInfoSingle: mock miss then trigger, job completed, then token w
   const originalFetch = global.fetch;
   let tokenRound = 0;
 
-  global.fetch = async (_url: string, init?: RequestInit) => {
+  global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
     const { query } = graphqlRequestFromInit(init);
     if (query.includes('triggerTokenIndexing')) {
       return jsonResponse({
@@ -497,7 +497,7 @@ test('getNFTTokenInfoSingle: mock polls media_assets when first hit has empty li
   const originalFetch = global.fetch;
   let tokenCalls = 0;
 
-  global.fetch = async (_url: string, init?: RequestInit) => {
+  global.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
     const { query } = graphqlRequestFromInit(init);
     if (query.includes('tokens(')) {
       tokenCalls += 1;
@@ -559,8 +559,9 @@ test(
   async (t) => {
     const { getNFTTokenInfoSingle, queryTokens, buildTokenCID } = nftIndexer;
     const chain = 'ethereum';
-    const contractAddress = '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb';
-    const tokenId = '7804';
+    // Fixture must exist on https://indexer.feralfile.com (verified via tokens query by contract).
+    const contractAddress = '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270';
+    const tokenId = '52000296';
     const tokenCID = String(buildTokenCID(chain, contractAddress, tokenId));
 
     const existing = await queryTokens({ token_cids: [tokenCID], limit: 1 });


### PR DESCRIPTION
## Problem

The NFT indexer client called GraphQL shapes that no longer match ff-indexer-v2: invalid `tokens` arguments and fields, split `metadata`/`enrichment` merging on the client, invalid `JobStatus` field selections, and deprecated `workflow_id`/`run_id` handling instead of `job_id`.

## Why It Matters

Production requests could fail validation or return wrong data. Aligning with the schema restores reliable token fetch, display data, and indexing job polling.

## Acceptance Checks

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (165 tests)
- [x] `npm run build`

## Documentation impact

- [ ] CLI surface changed (added/removed/renamed a command, flag, or argument) → updated [`feral-file/docs`](https://github.com/feral-file/docs) (`docs/api-reference/cli.md`, and any mentions under `docs/dp1-protocol/`, `docs/llm-agents/`)
- [ ] Config schema changed → updated `docs/CONFIGURATION.md` and the public docs as needed
- [x] No user-facing change — docs updates not required

## Human Owner

`@jollyjoker992` (or repository maintainers)

## How The Agent Will Be Used

Not applicable for this PR description.

## PR or Deploy Link

(This PR.)

Made with [Cursor](https://cursor.com)