### PR TITLE
ci(release): npm beta dist-tag for prereleases and manual publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
           node-version: '22'
 
       - name: Verify package version matches tag
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
@@ -64,8 +66,6 @@ jobs:
 
             echo "Version check passed: package.json and tag are both $PACKAGE_VERSION."
           else
-            VERSION_INPUT="${{ inputs.version }}"
-
             if [[ "$VERSION_INPUT" != *beta* ]]; then
               echo "Workflow dispatch beta runs must use a version containing 'beta'."
               exit 1
@@ -114,11 +114,13 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [[ "${{ inputs.version }}" != *beta* ]]; then
+            if [[ "$VERSION_INPUT" != *beta* ]]; then
               echo "Workflow dispatch beta runs must use a version containing 'beta'."
               exit 1
             fi
@@ -135,10 +137,12 @@ jobs:
 
       - name: Verify beta publish
         if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
-          EXPECTED_VERSION="${{ inputs.version }}"
+          EXPECTED_VERSION="$VERSION_INPUT"
           ATTEMPTS=10
           SLEEP_SECONDS=10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,77 @@
 # On release publish: run build workflow, then upload artifacts to the existing release.
+# npm dist-tag matches display-protocol/dp1-js publish.yml: stable releases use `latest`;
+# GitHub prereleases and optional manual runs can publish to `beta`.
 name: Release
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.0.18-beta.0)'
+        required: true
+        type: string
+      beta:
+        description: 'Publish to the beta dist-tag (false = latest)'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   ci:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/ci.yml
 
-  verify-version:
+  # Resolves whether npm publish targets the `beta` dist-tag (same rules as dp1-js publish.yml).
+  publish-meta:
+    runs-on: ubuntu-latest
+    outputs:
+      beta: ${{ steps.meta.outputs.beta }}
+    steps:
+      - id: meta
+        run: |
+          set -euo pipefail
+          EVENT="${GITHUB_EVENT_NAME}"
+          if [ "${EVENT}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.beta }}" = "true" ]; then
+              echo "beta=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "beta=false" >> "$GITHUB_OUTPUT"
+            fi
+          elif [ "${EVENT}" = "release" ]; then
+            if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+              echo "beta=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "beta=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Unsupported event: ${EVENT}" >&2
+            exit 1
+          fi
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+
+  pre-publish:
+    needs: [ci]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name == 'release'
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
+        if: github.event_name == 'release'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
 
       - name: Verify package version matches tag
+        if: github.event_name == 'release'
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAG_VERSION="${{ github.event.release.tag_name }}"
-          else
-            TAG_VERSION="${{ github.ref_name }}"
-          fi
+          TAG_VERSION="${{ github.event.release.tag_name }}"
 
           if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: package.json is $PACKAGE_VERSION but tag is $TAG_VERSION."
@@ -39,10 +81,15 @@ jobs:
 
           echo "Version check passed: package.json and tag are both $PACKAGE_VERSION."
 
+      - name: Manual npm publish (no tag gate)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Skipping tag check; npm version is applied from the workflow input before publish."
+
   build:
     needs:
       - ci
-      - verify-version
+      - pre-publish
     if: github.event_name == 'release'
     uses: ./.github/workflows/build.yml
     with:
@@ -52,8 +99,8 @@ jobs:
   publish-npm:
     needs:
       - ci
-      - verify-version
-    if: github.event_name == 'release'
+      - pre-publish
+      - publish-meta
     runs-on: ubuntu-latest
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -71,7 +118,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Publish to npm
+      # npm version exits 1 when the version is already set ("Version not changed").
+      - name: Set package version (manual publish only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          TARGET="${{ inputs.version }}"
+          CURRENT="$(node -p "require('./package.json').version")"
+          if [ "${CURRENT}" != "${TARGET}" ]; then
+            npm version "${TARGET}" --no-git-tag-version
+          else
+            echo "package.json already at ${TARGET}; skipping npm version."
+          fi
+
+      - name: Publish to npm (beta)
+        if: needs.publish-meta.outputs.beta == 'true'
+        run: npm publish --tag beta --access public
+
+      - name: Publish to npm (latest)
+        if: needs.publish-meta.outputs.beta != 'true'
         run: npm publish --access public
 
   upload-release-assets:
@@ -107,7 +172,7 @@ jobs:
           GIT_WORK_TREE: ${{ github.workspace }}
 
   verify-release:
-    needs: [publish-npm, upload-release-assets]
+    needs: [publish-npm, upload-release-assets, publish-meta]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
@@ -144,13 +209,24 @@ jobs:
           set -euo pipefail
 
           TAG="${{ github.event.release.tag_name }}"
+          BETA="${{ needs.publish-meta.outputs.beta }}"
+          if [ "$BETA" = "true" ]; then
+            DIST_LABEL="beta"
+          else
+            DIST_LABEL="latest"
+          fi
           ATTEMPTS=10
           SLEEP_SECONDS=10
 
           for attempt in $(seq 1 "$ATTEMPTS"); do
-            NPM_VERSION=$(npm view ff1-cli version)
+            if [ "$BETA" = "true" ]; then
+              NPM_VERSION=$(npm view ff1-cli@beta version)
+            else
+              NPM_VERSION=$(npm view ff1-cli version)
+            fi
+
             if [ "$NPM_VERSION" = "$TAG" ]; then
-              echo "npm version check passed: $NPM_VERSION"
+              echo "npm version check passed: $NPM_VERSION (dist-tag ${DIST_LABEL})"
               exit 0
             fi
 
@@ -160,5 +236,5 @@ jobs:
             fi
           done
 
-          echo "npm version check failed: expected $TAG"
+          echo "npm version check failed: expected $TAG on dist-tag ${DIST_LABEL}"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,85 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (e.g. 1.0.18-beta.0)"
+        description: "Version to publish (for beta runs, include beta in the version)"
         required: true
         type: string
 
 jobs:
   ci:
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release' || github.ref_name == 'main'
     uses: ./.github/workflows/ci.yml
 
+  dispatch-guard:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require workflow dispatch from main
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Workflow dispatch beta runs must be started from main."
+            exit 1
+          fi
+
+          echo "Workflow dispatch is running from main."
+
+  verify-version:
+    if: github.event_name == 'release' || github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Verify package version matches tag
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            PACKAGE_VERSION=$(node -p "require('./package.json').version")
+            TAG_VERSION="${{ github.event.release.tag_name }}"
+
+            if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+              echo "Version mismatch: package.json is $PACKAGE_VERSION but tag is $TAG_VERSION."
+              echo "Before cutting a release, set package.json version to the exact tag (example: tag 1.0.2 -> version 1.0.2)."
+              exit 1
+            fi
+
+            if [ "${{ github.event.release.prerelease }}" = "true" ] && [[ "$PACKAGE_VERSION" != *beta* ]]; then
+              echo "Beta releases must use a version containing 'beta'."
+              exit 1
+            fi
+
+            echo "Version check passed: package.json and tag are both $PACKAGE_VERSION."
+          else
+            VERSION_INPUT="${{ inputs.version }}"
+
+            if [[ "$VERSION_INPUT" != *beta* ]]; then
+              echo "Workflow dispatch beta runs must use a version containing 'beta'."
+              exit 1
+            fi
+
+            PACKAGE_VERSION=$(node -p "require('./package.json').version")
+            if [ "$PACKAGE_VERSION" != "$VERSION_INPUT" ]; then
+              echo "Version mismatch: package.json is $PACKAGE_VERSION but workflow input is $VERSION_INPUT."
+              echo "Before running the manual beta publish, set package.json version to the exact input version."
+              exit 1
+            fi
+
+            echo "Version check passed: package.json and workflow input are both $PACKAGE_VERSION."
+          fi
+
   build:
-    needs: [ci, publish-npm]
+    needs:
+      - ci
+      - verify-version
     if: github.event_name == 'release'
     uses: ./.github/workflows/build.yml
     with:
@@ -24,8 +92,10 @@ jobs:
     secrets: inherit
 
   publish-npm:
-    needs: [ci]
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs:
+      - ci
+      - verify-version
+    if: github.event_name == 'release' || github.ref_name == 'main'
     runs-on: ubuntu-latest
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -37,62 +107,56 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
 
-      - id: meta
-        name: Resolve publish metadata
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}"
-          TAG="latest"
-
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            TAG="beta"
-          elif [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            TAG="beta"
-          fi
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify package version matches tag
-        if: github.event_name == 'release'
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${{ steps.meta.outputs.version }}"
-
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version mismatch: package.json is $PACKAGE_VERSION but tag is $TAG_VERSION."
-            echo "Before cutting a release, set package.json version to the exact tag (example: tag 1.0.2 -> version 1.0.2)."
-            exit 1
-          fi
-
-          echo "Version check passed: package.json and tag are both $PACKAGE_VERSION."
-
-      - name: Set package version
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          set -euo pipefail
-          TARGET="${{ steps.meta.outputs.version }}"
-          CURRENT="$(node -p "require('./package.json').version")"
-          if [ "${CURRENT}" != "${TARGET}" ]; then
-            npm version "${TARGET}" --no-git-tag-version
-          else
-            echo "package.json already at ${TARGET}; skipping npm version."
-          fi
-
       - name: Publish to npm
         run: |
-          if [ "${{ steps.meta.outputs.tag }}" = "beta" ]; then
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [[ "${{ inputs.version }}" != *beta* ]]; then
+              echo "Workflow dispatch beta runs must use a version containing 'beta'."
+              exit 1
+            fi
+            npm publish --tag beta --access public
+          elif [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            if [[ "${{ github.event.release.tag_name }}" != *beta* ]]; then
+              echo "Beta releases must use a tag containing 'beta'."
+              exit 1
+            fi
             npm publish --tag beta --access public
           else
             npm publish --access public
           fi
+
+      - name: Verify beta publish
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+
+          EXPECTED_VERSION="${{ inputs.version }}"
+          ATTEMPTS=10
+          SLEEP_SECONDS=10
+
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            NPM_VERSION=$(npm view ff-cli dist-tags.beta)
+            if [ "$NPM_VERSION" = "$EXPECTED_VERSION" ]; then
+              echo "npm beta dist-tag check passed: $NPM_VERSION"
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
+              echo "npm beta dist-tag is $NPM_VERSION, expected $EXPECTED_VERSION; retrying in ${SLEEP_SECONDS}s (${attempt}/${ATTEMPTS})"
+              sleep "$SLEEP_SECONDS"
+            fi
+          done
+
+          echo "npm beta dist-tag check failed: expected $EXPECTED_VERSION"
+          exit 1
 
   upload-release-assets:
     needs: build
@@ -158,3 +222,33 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Verify npm package version
+        run: |
+          set -euo pipefail
+
+          TAG="${{ github.event.release.tag_name }}"
+          ATTEMPTS=10
+          SLEEP_SECONDS=10
+
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            NPM_QUERY="npm view ff-cli dist-tags.beta"
+          else
+            NPM_QUERY="npm view ff-cli version"
+          fi
+
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            NPM_VERSION=$($NPM_QUERY)
+            if [ "$NPM_VERSION" = "$TAG" ]; then
+              echo "npm version check passed: $NPM_VERSION"
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
+              echo "npm version is $NPM_VERSION, expected $TAG; retrying in ${SLEEP_SECONDS}s (${attempt}/${ATTEMPTS})"
+              sleep "$SLEEP_SECONDS"
+            fi
+          done
+
+          echo "npm version check failed: expected $TAG"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
 
   build:
-    needs: [ci]
+    needs: [ci, publish-npm]
     if: github.event_name == 'release'
     uses: ./.github/workflows/build.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 1.0.18-beta.0)'
+        description: "Version to publish (e.g. 1.0.18-beta.0)"
         required: true
         type: string
       beta:
-        description: 'Publish to the beta dist-tag (false = latest)'
+        description: "Publish to the beta dist-tag (false = latest)"
         required: false
         default: true
         type: boolean
@@ -65,7 +65,7 @@ jobs:
         if: github.event_name == 'release'
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Verify package version matches tag
         if: github.event_name == 'release'
@@ -84,7 +84,7 @@ jobs:
       - name: Manual npm publish (no tag gate)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "Skipping tag check; npm version is applied from the workflow input before publish."
+          echo "Skipping tag check: npm publish uses the version already in package.json on the checked-out ref."
 
   build:
     needs:
@@ -102,6 +102,8 @@ jobs:
       - pre-publish
       - publish-meta
     runs-on: ubuntu-latest
+    outputs:
+      expected_version: ${{ steps.pkg.outputs.version }}
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -112,8 +114,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -130,6 +132,12 @@ jobs:
           else
             echo "package.json already at ${TARGET}; skipping npm version."
           fi
+
+      # After optional manual version bump, record exactly what npm publish will ship.
+      - id: pkg
+        name: Record package version for npm verification
+        run: |
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm (beta)
         if: needs.publish-meta.outputs.beta == 'true'
@@ -171,8 +179,54 @@ jobs:
           GIT_DIR: ${{ github.workspace }}/.git
           GIT_WORK_TREE: ${{ github.workspace }}
 
+  # Confirms the package is visible on the intended dist-tag for every path that runs publish-npm.
+  verify-npm:
+    needs: [publish-npm, publish-meta]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Verify npm package version on dist-tag
+        run: |
+          set -euo pipefail
+
+          EXPECTED="${{ needs.publish-npm.outputs.expected_version }}"
+          BETA="${{ needs.publish-meta.outputs.beta }}"
+          if [ "$BETA" = "true" ]; then
+            DIST_LABEL="beta"
+          else
+            DIST_LABEL="latest"
+          fi
+          ATTEMPTS=10
+          SLEEP_SECONDS=10
+
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            if [ "$BETA" = "true" ]; then
+              NPM_VERSION=$(npm view ff1-cli@beta version)
+            else
+              NPM_VERSION=$(npm view ff1-cli version)
+            fi
+
+            if [ "$NPM_VERSION" = "$EXPECTED" ]; then
+              echo "npm version check passed: $NPM_VERSION (dist-tag ${DIST_LABEL})"
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
+              echo "npm version is $NPM_VERSION, expected $EXPECTED; retrying in ${SLEEP_SECONDS}s (${attempt}/${ATTEMPTS})"
+              sleep "$SLEEP_SECONDS"
+            fi
+          done
+
+          echo "npm version check failed: expected $EXPECTED on dist-tag ${DIST_LABEL}"
+          exit 1
+
   verify-release:
-    needs: [publish-npm, upload-release-assets, publish-meta]
+    needs: [verify-npm, upload-release-assets]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
@@ -203,38 +257,3 @@ jobs:
               exit 1
             fi
           done
-
-      - name: Verify npm package version
-        run: |
-          set -euo pipefail
-
-          TAG="${{ github.event.release.tag_name }}"
-          BETA="${{ needs.publish-meta.outputs.beta }}"
-          if [ "$BETA" = "true" ]; then
-            DIST_LABEL="beta"
-          else
-            DIST_LABEL="latest"
-          fi
-          ATTEMPTS=10
-          SLEEP_SECONDS=10
-
-          for attempt in $(seq 1 "$ATTEMPTS"); do
-            if [ "$BETA" = "true" ]; then
-              NPM_VERSION=$(npm view ff1-cli@beta version)
-            else
-              NPM_VERSION=$(npm view ff1-cli version)
-            fi
-
-            if [ "$NPM_VERSION" = "$TAG" ]; then
-              echo "npm version check passed: $NPM_VERSION (dist-tag ${DIST_LABEL})"
-              exit 0
-            fi
-
-            if [ "$attempt" -lt "$ATTEMPTS" ]; then
-              echo "npm version is $NPM_VERSION, expected $TAG; retrying in ${SLEEP_SECONDS}s (${attempt}/${ATTEMPTS})"
-              sleep "$SLEEP_SECONDS"
-            fi
-          done
-
-          echo "npm version check failed: expected $TAG on dist-tag ${DIST_LABEL}"
-          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Manual npm publish (no tag gate)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "Skipping tag check: npm publish uses the version already in package.json on the checked-out ref."
+          echo "Skipping release tag check. Publish job may set version from the workflow version input (npm version) before npm publish."
 
   build:
     needs:
@@ -119,6 +119,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Avoid accidentally publishing a feature-branch tree to the stable dist-tag.
+      - name: Guard manual publish to latest off main
+        if: github.event_name == 'workflow_dispatch' && inputs.beta == false
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error title=Invalid ref for npm latest::Manual publish to dist-tag latest is only allowed from refs/heads/main. Current: ${GITHUB_REF}"
+            exit 1
+          fi
 
       # npm version exits 1 when the version is already set ("Version not changed").
       - name: Set package version (manual publish only)
@@ -208,7 +217,7 @@ jobs:
             if [ "$BETA" = "true" ]; then
               NPM_VERSION=$(npm view ff1-cli@beta version)
             else
-              NPM_VERSION=$(npm view ff1-cli version)
+              NPM_VERSION=$(npm view ff1-cli@latest version)
             fi
 
             if [ "$NPM_VERSION" = "$EXPECTED" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# On release publish: run build workflow, then upload artifacts to the existing release.
-# npm dist-tag matches display-protocol/dp1-js publish.yml: stable releases use `latest`;
-# GitHub prereleases and optional manual runs can publish to `beta`.
 name: Release
 
 on:
@@ -12,84 +9,14 @@ on:
         description: "Version to publish (e.g. 1.0.18-beta.0)"
         required: true
         type: string
-      beta:
-        description: "Publish to the beta dist-tag (false = latest)"
-        required: false
-        default: true
-        type: boolean
 
 jobs:
   ci:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/ci.yml
 
-  # Resolves whether npm publish targets the `beta` dist-tag (same rules as dp1-js publish.yml).
-  publish-meta:
-    runs-on: ubuntu-latest
-    outputs:
-      beta: ${{ steps.meta.outputs.beta }}
-    steps:
-      - id: meta
-        run: |
-          set -euo pipefail
-          EVENT="${GITHUB_EVENT_NAME}"
-          if [ "${EVENT}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.beta }}" = "true" ]; then
-              echo "beta=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "beta=false" >> "$GITHUB_OUTPUT"
-            fi
-          elif [ "${EVENT}" = "release" ]; then
-            if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-              echo "beta=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "beta=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "Unsupported event: ${EVENT}" >&2
-            exit 1
-          fi
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-
-  pre-publish:
-    needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        if: github.event_name == 'release'
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        if: github.event_name == 'release'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Verify package version matches tag
-        if: github.event_name == 'release'
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${{ github.event.release.tag_name }}"
-
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version mismatch: package.json is $PACKAGE_VERSION but tag is $TAG_VERSION."
-            echo "Before cutting a release, set package.json version to the exact tag (example: tag 1.0.2 -> version 1.0.2)."
-            exit 1
-          fi
-
-          echo "Version check passed: package.json and tag are both $PACKAGE_VERSION."
-
-      - name: Manual npm publish (no tag gate)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "Skipping release tag check. Publish job may set version from the workflow version input (npm version) before npm publish."
-
   build:
-    needs:
-      - ci
-      - pre-publish
+    needs: [ci]
     if: github.event_name == 'release'
     uses: ./.github/workflows/build.yml
     with:
@@ -97,13 +24,9 @@ jobs:
     secrets: inherit
 
   publish-npm:
-    needs:
-      - ci
-      - pre-publish
-      - publish-meta
+    needs: [ci]
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    outputs:
-      expected_version: ${{ steps.pkg.outputs.version }}
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -120,21 +43,42 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Avoid accidentally publishing a feature-branch tree to the stable dist-tag.
-      - name: Guard manual publish to latest off main
-        if: github.event_name == 'workflow_dispatch' && inputs.beta == false
+      - id: meta
+        name: Resolve publish metadata
         run: |
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "::error title=Invalid ref for npm latest::Manual publish to dist-tag latest is only allowed from refs/heads/main. Current: ${GITHUB_REF}"
+          set -euo pipefail
+
+          VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}"
+          TAG="latest"
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="beta"
+          elif [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            TAG="beta"
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify package version matches tag
+        if: github.event_name == 'release'
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${{ steps.meta.outputs.version }}"
+
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: package.json is $PACKAGE_VERSION but tag is $TAG_VERSION."
+            echo "Before cutting a release, set package.json version to the exact tag (example: tag 1.0.2 -> version 1.0.2)."
             exit 1
           fi
 
-      # npm version exits 1 when the version is already set ("Version not changed").
-      - name: Set package version (manual publish only)
+          echo "Version check passed: package.json and tag are both $PACKAGE_VERSION."
+
+      - name: Set package version
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          TARGET="${{ inputs.version }}"
+          TARGET="${{ steps.meta.outputs.version }}"
           CURRENT="$(node -p "require('./package.json').version")"
           if [ "${CURRENT}" != "${TARGET}" ]; then
             npm version "${TARGET}" --no-git-tag-version
@@ -142,19 +86,13 @@ jobs:
             echo "package.json already at ${TARGET}; skipping npm version."
           fi
 
-      # After optional manual version bump, record exactly what npm publish will ship.
-      - id: pkg
-        name: Record package version for npm verification
+      - name: Publish to npm
         run: |
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Publish to npm (beta)
-        if: needs.publish-meta.outputs.beta == 'true'
-        run: npm publish --tag beta --access public
-
-      - name: Publish to npm (latest)
-        if: needs.publish-meta.outputs.beta != 'true'
-        run: npm publish --access public
+          if [ "${{ steps.meta.outputs.tag }}" = "beta" ]; then
+            npm publish --tag beta --access public
+          else
+            npm publish --access public
+          fi
 
   upload-release-assets:
     needs: build
@@ -188,54 +126,8 @@ jobs:
           GIT_DIR: ${{ github.workspace }}/.git
           GIT_WORK_TREE: ${{ github.workspace }}
 
-  # Confirms the package is visible on the intended dist-tag for every path that runs publish-npm.
-  verify-npm:
-    needs: [publish-npm, publish-meta]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Verify npm package version on dist-tag
-        run: |
-          set -euo pipefail
-
-          EXPECTED="${{ needs.publish-npm.outputs.expected_version }}"
-          BETA="${{ needs.publish-meta.outputs.beta }}"
-          if [ "$BETA" = "true" ]; then
-            DIST_LABEL="beta"
-          else
-            DIST_LABEL="latest"
-          fi
-          ATTEMPTS=10
-          SLEEP_SECONDS=10
-
-          for attempt in $(seq 1 "$ATTEMPTS"); do
-            if [ "$BETA" = "true" ]; then
-              NPM_VERSION=$(npm view ff1-cli@beta version)
-            else
-              NPM_VERSION=$(npm view ff1-cli@latest version)
-            fi
-
-            if [ "$NPM_VERSION" = "$EXPECTED" ]; then
-              echo "npm version check passed: $NPM_VERSION (dist-tag ${DIST_LABEL})"
-              exit 0
-            fi
-
-            if [ "$attempt" -lt "$ATTEMPTS" ]; then
-              echo "npm version is $NPM_VERSION, expected $EXPECTED; retrying in ${SLEEP_SECONDS}s (${attempt}/${ATTEMPTS})"
-              sleep "$SLEEP_SECONDS"
-            fi
-          done
-
-          echo "npm version check failed: expected $EXPECTED on dist-tag ${DIST_LABEL}"
-          exit 1
-
   verify-release:
-    needs: [verify-npm, upload-release-assets]
+    needs: [publish-npm, upload-release-assets]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,7 +36,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 - **Stable vs beta on npm** (same idea as `display-protocol/dp1-js` `publish.yml`):
   - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
   - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff1-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
-  - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`) and choose `beta` vs `latest`; after publish, the workflow fails if `ff1-cli` on that dist-tag does not match the version that was shipped.
+  - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`) and choose `beta` vs `latest`; after publish, the workflow fails if `ff1-cli` on that dist-tag does not match the version that was shipped. Publishing to **`latest` from a manual run is allowed only when the workflow runs from the **`main`** branch (guarded in CI) so ad-hoc branches cannot overwrite the stable dist-tag by mistake.
 
 ## Release notes and breaking changes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,12 +27,16 @@ Run the appropriate script on each target platform and upload each pair to the G
 ## GitHub Actions
 
 - **Build** (`build.yml`): Trigger manually (Actions → Build → Run workflow) or on pull requests. Builds binaries on macOS, Linux, and Windows and uploads them as workflow artifacts for download.
-- **Release** (`release.yml`): Runs a fast version check on every pushed tag and fails if `package.json` does not match the tag exactly. When you **publish a release** (create a release from the repo Releases page, or publish an existing draft), it validates again, publishes to npm, builds binaries, then uploads them to that release.
+- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, builds binaries, then uploads assets to that release. Optional **manual run** (Actions → Release → Run workflow) can publish a given version to npm without creating a release (no binary upload); use that only when you intentionally bypass the normal tag + GitHub Release flow.
 
 ## npm Publish Requirements
 
 - Set `NPM_TOKEN` in GitHub Actions secrets with an npm automation token.
 - Ensure `package.json` version matches the release tag (e.g. tag `1.0.2` → `"version": "1.0.2"`). The release job fails fast when they differ.
+- **Stable vs beta on npm** (same idea as `display-protocol/dp1-js` `publish.yml`):
+  - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
+  - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff1-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
+  - **Manual workflow**: provide `version` and choose `beta` vs `latest`; this updates the checked-out `package.json` with `npm version` before publish, like the manual path in dp1-js.
 
 ## Release notes and breaking changes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,8 +34,8 @@ Run the appropriate script on each target platform and upload each pair to the G
 - Set `NPM_TOKEN` in GitHub Actions secrets with an npm automation token.
 - Ensure `package.json` version matches the release tag (e.g. tag `1.0.2` → `"version": "1.0.2"`). The release job fails fast when they differ.
 - **Stable vs beta on npm** (same idea as `display-protocol/dp1-js` `publish.yml`):
-  - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
-  - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff1-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
+- A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
+- A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
   - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`). The workflow then publishes that version to the **`beta`** dist-tag.
 
 ## Release notes and breaking changes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,16 +27,15 @@ Run the appropriate script on each target platform and upload each pair to the G
 ## GitHub Actions
 
 - **Build** (`build.yml`): Trigger manually (Actions → Build → Run workflow) or on pull requests. Builds binaries on macOS, Linux, and Windows and uploads them as workflow artifacts for download.
-- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, then builds binaries and uploads assets. Optional **manual run** (Actions → Release → Run workflow) publishes the provided version to the **`beta`** dist-tag, without creating a GitHub Release or binary upload—use only when you intentionally bypass the normal tag + GitHub Release flow.
+- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, then builds binaries and uploads assets. A GitHub Release marked as a pre-release publishes to the **`beta`** dist-tag; the version must also contain `beta`. A manual workflow dispatch can also publish a beta version when you need to bypass the normal release flow, but run it from `main`.
 
 ## npm Publish Requirements
 
 - Set `NPM_TOKEN` in GitHub Actions secrets with an npm automation token.
 - Ensure `package.json` version matches the release tag (e.g. tag `1.0.2` → `"version": "1.0.2"`). The release job fails fast when they differ.
-- **Stable vs beta on npm** (same idea as `display-protocol/dp1-js` `publish.yml`):
-- A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
-- A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
-  - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`). The workflow then publishes that version to the **`beta`** dist-tag.
+- A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`**.
+- A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag, and its version must contain `beta` so the package version stays aligned with the beta channel.
+- Manual workflow dispatch runs publish to the **`beta`** dist-tag too, and the `version` input must contain `beta`, match `package.json`, and be dispatched from `main`.
 
 ## Release notes and breaking changes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,7 +27,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 ## GitHub Actions
 
 - **Build** (`build.yml`): Trigger manually (Actions → Build → Run workflow) or on pull requests. Builds binaries on macOS, Linux, and Windows and uploads them as workflow artifacts for download.
-- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, builds binaries, then uploads assets to that release. Optional **manual run** (Actions → Release → Run workflow) can publish a given version to npm without creating a release (no binary upload); use that only when you intentionally bypass the normal tag + GitHub Release flow.
+- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, **re-checks the npm registry** for the expected dist-tag and version, then builds binaries and uploads assets. Optional **manual run** (Actions → Release → Run workflow) publishes with the same npm verification afterward, without creating a GitHub Release or binary upload—use only when you intentionally bypass the normal tag + GitHub Release flow.
 
 ## npm Publish Requirements
 
@@ -36,7 +36,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 - **Stable vs beta on npm** (same idea as `display-protocol/dp1-js` `publish.yml`):
   - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
   - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff1-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
-  - **Manual workflow**: provide `version` and choose `beta` vs `latest`; this updates the checked-out `package.json` with `npm version` before publish, like the manual path in dp1-js.
+  - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`) and choose `beta` vs `latest`; after publish, the workflow fails if `ff1-cli` on that dist-tag does not match the version that was shipped.
 
 ## Release notes and breaking changes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,7 +27,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 ## GitHub Actions
 
 - **Build** (`build.yml`): Trigger manually (Actions → Build → Run workflow) or on pull requests. Builds binaries on macOS, Linux, and Windows and uploads them as workflow artifacts for download.
-- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, **re-checks the npm registry** for the expected dist-tag and version, then builds binaries and uploads assets. Optional **manual run** (Actions → Release → Run workflow) publishes with the same npm verification afterward, without creating a GitHub Release or binary upload—use only when you intentionally bypass the normal tag + GitHub Release flow.
+- **Release** (`release.yml`): On **published** GitHub Releases, validates that `package.json` matches the tag, publishes to npm, then builds binaries and uploads assets. Optional **manual run** (Actions → Release → Run workflow) publishes the provided version to the **`beta`** dist-tag, without creating a GitHub Release or binary upload—use only when you intentionally bypass the normal tag + GitHub Release flow.
 
 ## npm Publish Requirements
 
@@ -36,7 +36,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 - **Stable vs beta on npm** (same idea as `display-protocol/dp1-js` `publish.yml`):
   - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`** (`npm publish` with no `--tag`).
   - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag (`npm publish --tag beta`). Consumers install with `npm install ff1-cli@beta` (or pin that dist-tag in CI) until you ship a stable release.
-  - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`) and choose `beta` vs `latest`; after publish, the workflow fails if `ff1-cli` on that dist-tag does not match the version that was shipped. Publishing to **`latest` from a manual run is allowed only when the workflow runs from the **`main`** branch (guarded in CI) so ad-hoc branches cannot overwrite the stable dist-tag by mistake.
+  - **Manual workflow**: provide `version` (CI runs `npm version` when it differs from `package.json`). The workflow then publishes that version to the **`beta`** dist-tag.
 
 ## Release notes and breaking changes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,6 +36,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`**.
 - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag, and its version must contain `beta` so the package version stays aligned with the beta channel.
 - Manual workflow dispatch runs publish to the **`beta`** dist-tag too, and the `version` input must contain `beta`, match `package.json`, and be dispatched from `main`.
+- Example beta version: `1.0.18-beta.0`.
 
 ## Release notes and breaking changes
 


### PR DESCRIPTION
## Summary

Keep the release workflow aligned with `main` while restoring manual `workflow_dispatch` support for beta publishes.

- GitHub Release prereleases still publish to `npm` with the `beta` dist-tag; stable releases keep `latest`.
- Manual `workflow_dispatch` is beta-only, requires a version containing `beta`, and must be started from `main`.
- Release verification now checks `npm view ff-cli version` for stable releases and `npm view ff-cli dist-tags.beta` for prereleases and manual beta dispatches.

## Docs

- `docs/RELEASING.md` now matches the workflow behavior for prereleases and manual beta dispatches.

## Verification

- `GROK_API_KEY=dummy npm run verify`
- `ReadLints` for `.github/workflows/release.yml` and `docs/RELEASING.md`