### PR TITLE
Rename ff1-cli to ff-cli

### DIFF
--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -1,11 +1,11 @@
 ---
 name: reviewer
 model: premium
-description: Read-only code reviewer for FF1-CLI. Use after implementation for a fresh-context review.
+description: Read-only code reviewer for ff-cli. Use after implementation for a fresh-context review.
 readonly: true
 ---
 
-You are the project reviewer for `ff1-cli`.
+You are the project reviewer for `ff-cli`.
 
 Read and follow `prompts/code-review.md` as the full review contract.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build asset
         run: ${{ matrix.script }}
         env:
-          FF1_CLI_VERSION: ${{ github.event_name == 'pull_request' && '0.1' || inputs.version }}
+          FF_CLI_VERSION: ${{ github.event_name == 'pull_request' && '0.1' || inputs.version }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,12 +121,12 @@ jobs:
 
           TAG="${{ github.event.release.tag_name }}"
           REQUIRED_ASSETS=(
-            "ff1-cli-darwin-arm64.tar.gz"
-            "ff1-cli-darwin-arm64.tar.gz.sha256"
-            "ff1-cli-linux-x64.tar.gz"
-            "ff1-cli-linux-x64.tar.gz.sha256"
-            "ff1-cli-windows-x64.zip"
-            "ff1-cli-windows-x64.zip.sha256"
+            "ff-cli-darwin-arm64.tar.gz"
+            "ff-cli-darwin-arm64.tar.gz.sha256"
+            "ff-cli-linux-x64.tar.gz"
+            "ff-cli-linux-x64.tar.gz.sha256"
+            "ff-cli-windows-x64.zip"
+            "ff-cli-windows-x64.zip.sha256"
           )
 
           RELEASE_ASSETS=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
@@ -148,7 +148,7 @@ jobs:
           SLEEP_SECONDS=10
 
           for attempt in $(seq 1 "$ATTEMPTS"); do
-            NPM_VERSION=$(npm view ff1-cli version)
+            NPM_VERSION=$(npm view ff-cli version)
             if [ "$NPM_VERSION" = "$TAG" ]; then
               echo "npm version check passed: $NPM_VERSION"
               exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
-# AGENTS.md — FF1-CLI Repository Contract
+# AGENTS.md — ff-cli Repository Contract
 
-This file is the repository-level contract for humans and coding agents working in `ff1-cli`.
+This file is the repository-level contract for humans and coding agents working in `ff-cli`.
 
 It defines how work is done in this repo. Tool-specific details live in `.cursor/`, `opencode.json`, and shared review prompts.
 
 ## Repository overview
 
-- Project: `ff1-cli`
+- Project: `ff-cli`
 - Purpose: a Node.js CLI for FF1 computational art workflows, DP-1 envelopes, playlist validation, playlist publishing, and FF1 device operations
 - Primary runtime: Node.js + TypeScript
 - Domain terms to keep consistent: `FF1`, `DP-1 envelope`, `DP-1 conformance`, `computational art playlist`, `channel endorsement`, `FF1 device`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# FF1-CLI
+# ff-cli
 
 A small Node.js CLI for building DP-1 playlists from NFT collections.
 
 **Runtime:** Node.js 22 or newer (matches CI and the `dp1-js` dependency). That engine floor is a **breaking** change if you previously used Node 18 or 20—check the **GitHub Release** for the version you move to; release authors follow `docs/RELEASING.md` so the notes stay explicit.
 
-FF1-CLI turns a simple prompt into a DP-1–conformant playlist you can preview on an FF1. The model orchestrates; deterministic tools do the real work (schema validation, indexing, JSON‑LD). If something comes back invalid, validation rejects it and we loop until it’s right.
+ff-cli turns a simple prompt into a DP-1–conformant playlist you can preview on an Art Computer. The model orchestrates; deterministic tools do the real work (schema validation, indexing, JSON‑LD). If something comes back invalid, validation rejects it and we loop until it’s right.
 
 ## Install
 
 ```bash
-npm i -g ff1-cli
+npm i -g ff-cli
 ```
 
 ## Install (curl)
 
 ```bash
-curl -fsSL https://feralfile.com/ff1-cli-install | bash
+curl -fsSL https://feralfile.com/ff-cli-install | bash
 ```
 
 Installs a prebuilt binary for macOS/Linux (no Node.js required).
@@ -23,8 +23,8 @@ Installs a prebuilt binary for macOS/Linux (no Node.js required).
 ## One-off Usage (npx)
 
 ```bash
-npx ff1-cli setup
-npx ff1-cli chat
+npx ff-cli setup
+npx ff-cli chat
 ```
 
 ## Quick Start
@@ -32,16 +32,16 @@ npx ff1-cli chat
 **Set your LLM API key first (default Grok):** `export GROK_API_KEY='xai-your-api-key-here'`
 
 ```bash
-ff1 setup
-ff1 chat
-ff1 play "https://example.com/video.mp4" --skip-verify
+ff-cli setup
+ff-cli chat
+ff-cli play "https://example.com/video.mp4" --skip-verify
 ```
 
 If you need manual config actions instead of guided setup:
 
 ```bash
-ff1 config init
-ff1 config validate
+ff-cli config init
+ff-cli config validate
 ```
 
 ## Dev Quick Start
@@ -61,7 +61,7 @@ npm run dev -- play "https://example.com/video.mp4" --skip-verify
 - Configuration: `./docs/CONFIGURATION.md`
 - Function calling architecture: `./docs/FUNCTION_CALLING.md`
 - Examples: `./docs/EXAMPLES.md`
-- SSH access: `ff1 ssh enable|disable` in `./docs/README.md`
+- SSH access: `ff-cli ssh enable|disable` in `./docs/README.md`
 
 ## Verification
 

--- a/build.js
+++ b/build.js
@@ -18,7 +18,7 @@ async function build() {
       platform: 'node',
       target: 'node22',
       format: 'cjs',
-      outfile: 'dist/ff1.js',
+      outfile: 'dist/ff-cli.js',
       banner: {
         js: '#!/usr/bin/env node',
       },
@@ -34,7 +34,7 @@ async function build() {
 
     // Make the output file executable
     const { readFile, writeFile } = require('fs/promises');
-    const outfile = path.join(__dirname, 'dist', 'ff1.js');
+    const outfile = path.join(__dirname, 'dist', 'ff-cli.js');
 
     // Remove any duplicate shebangs that may have been bundled from source
     const content = await readFile(outfile, 'utf8');
@@ -50,8 +50,8 @@ async function build() {
     await writeFile(outfile, filteredLines.join('\n'));
     await chmod(outfile, 0o755);
 
-    console.log('\nBuild complete. Single executable: dist/ff1.js');
-    console.log('   Run with: ./dist/ff1.js or node dist/ff1.js\n');
+    console.log('\nBuild complete. Single executable: dist/ff-cli.js');
+    console.log('   Run with: ./dist/ff-cli.js or node dist/ff-cli.js\n');
   } catch (error) {
     console.error('Build failed:', error);
     process.exit(1);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Configuration Guide
 
-This guide explains how to configure FF1‑CLI, field by field. Configuration priority is:
+This guide explains how to configure ff-cli, field by field. Configuration priority is:
 
 - `config.json` (highest)
 - `.env`
@@ -61,8 +61,8 @@ Used for signing DP‑1 playlists.
 
 - `playlist.privateKey` (string, Ed25519 private key in hex or base64): Used by the `sign` command to create DP-1 v1.1.0 multi-signatures. The `verify` command may derive the matching public key from this value (or `PLAYLIST_PRIVATE_KEY`) when you omit `--public-key`; **dp1-js applies that derived key only when verifying legacy flat `signature` strings**, not when checking `signatures[]` envelopes. If that derivation fails, `verify` prints a warning on stderr and continues without derived key material. The derived public key is emitted as PEM so Node can decode it without ambiguity. Hex may include or omit the `0x` prefix. You can also set this via `PLAYLIST_PRIVATE_KEY` in `.env`.
 
-  **Signing and key encoding:** Signing paths (`sign`, deterministic `build` when configured, and `-k/--key` overrides) pass the private key string through to **`dp1-js`** (`SignMultiEd25519`) without an extra decoding step in ff1-cli. `dp1-js` recognizes **hex** (optional `0x`) or **base64** encodings of the PKCS#8 DER blob produced by the OpenSSL examples below, then loads the key for Ed25519. Use those formats; ff1-cli does not add a separate normalizer ahead of the library.
-- `playlist.role` (string): DP-1 signing role that travels with the private key. Defaults to `agent` if omitted. You can also set this via `PLAYLIST_ROLE` in `.env`. Guided `ff1 setup`, `config validate`, and `sign --role` only accept the usual DP-1 signing roles (`agent`, `feed`, `curator`, `institution`, `licensor`).
+  **Signing and key encoding:** Signing paths (`sign`, deterministic `build` when configured, and `-k/--key` overrides) pass the private key string through to **`dp1-js`** (`SignMultiEd25519`) without an extra decoding step in ff-cli. `dp1-js` recognizes **hex** (optional `0x`) or **base64** encodings of the PKCS#8 DER blob produced by the OpenSSL examples below, then loads the key for Ed25519. Use those formats; ff-cli does not add a separate normalizer ahead of the library.
+- `playlist.role` (string): DP-1 signing role that travels with the private key. Defaults to `agent` if omitted. You can also set this via `PLAYLIST_ROLE` in `.env`. Guided `ff-cli setup`, `config validate`, and `sign --role` only accept the usual DP-1 signing roles (`agent`, `feed`, `curator`, `institution`, `licensor`).
 ### Generate an Ed25519 private key
 
 You can generate a key locally. The CLI accepts either base64 (preferred) or hex
@@ -120,14 +120,14 @@ Configure devices you want to play content on.
   - `name` (string): Friendly device label. Free‑form; pick anything memorable.
   - `host` (string): Device base URL. For LAN devices, use `http://<ip>:1111`. The device typically listens on port `1111`.
 
-During `ff1 setup`, the CLI will attempt local discovery via mDNS (`_ff1._tcp`). If devices are found, you can pick one and the host will be filled in automatically. If discovery returns nothing, setup falls back to manual entry.
+During `ff-cli setup`, the CLI will attempt local discovery via mDNS (`_ff1._tcp`). If devices are found, you can pick one and the host will be filled in automatically. If discovery returns nothing, setup falls back to manual entry.
 
 You can also manage devices independently with:
 
-- `ff1 device add` – Add a device interactively (with mDNS discovery), or non-interactively with `--host` and `--name`.
-- `ff1 device list` – Show all configured devices.
-- `ff1 device remove <name>` – Remove a device by name.
-- `ff1 device default <name>` – Promote a device to the top of the list so it is used when `-d` is omitted.
+- `ff-cli device add` – Add a device interactively (with mDNS discovery), or non-interactively with `--host` and `--name`.
+- `ff-cli device list` – Show all configured devices.
+- `ff-cli device remove <name>` – Remove a device by name.
+- `ff-cli device default <name>` – Promote a device to the top of the list so it is used when `-d` is omitted.
 
 Setup and `device add` both preserve existing devices. Adding a device with the same host as an existing one updates it in place.
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -18,20 +18,20 @@ npm run dev -- config validate
 
 ## OpenClaw skill prompt
 
-If you want OpenClaw to run FF1 CLI end-to-end without confirmation, start from:
+If you want OpenClaw to run ff-cli end-to-end without confirmation, start from:
 
-`skills/ff1-control/SKILL.md`
+`skills/ff-control/SKILL.md`
 
 Recommended local install path:
 
 ```bash
 mkdir -p ~/.openclaw/skills
-ln -sfn ~/Work/ff1-cli/skills/ff1-control ~/.openclaw/skills/ff1-control
+ln -sfn ~/Work/ff-cli/skills/ff-control ~/.openclaw/skills/ff-control
 ```
 
 Compatibility copy (same prompt):
 
-`examples/openclaw-ff1-skill.md`
+`examples/openclaw-ff-skill.md`
 
 Paste that prompt into your OpenClaw skill config, then test with plain requests like:
 
@@ -134,8 +134,8 @@ npm run dev chat
 ### Combined: Display + Publish
 
 ```bash
-# Display on FF1 AND publish to feed
-npm run dev -- chat "Build playlist from contract 0xb932a70A57673d89f4acfFBE830E8ed7f75Fb9e0 with tokens 52932 and 52457; mix them up; send to my FF1 and publish to my feed" -o playlist.json -v
+# Display on Art Computer AND publish to feed
+npm run dev -- chat "Build playlist from contract 0xb932a70A57673d89f4acfFBE830E8ed7f75Fb9e0 with tokens 52932 and 52457; mix them up; send to my Art Computer and publish to my feed" -o playlist.json -v
 
 # With explicit device name
 npm run dev -- chat "Get 5 from Unsupervised, shuffle, display on 'Living Room', and publish to feed" -v

--- a/docs/FUNCTION_CALLING.md
+++ b/docs/FUNCTION_CALLING.md
@@ -1,6 +1,6 @@
 # Function Calling Architecture
 
-How FF1‑CLI uses AI function calling to build playlists deterministically. The model orchestrates function calls; tools enforce schema and assemble the DP-1 envelope.
+How ff-cli uses AI function calling to build playlists deterministically. The model orchestrates function calls; tools enforce schema and assemble the DP-1 envelope.
 
 ## Overview
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -1,6 +1,6 @@
-# FF1-CLI Project Spec
+# ff-cli Project Spec
 
-This document defines the current product role, boundaries, and constraints for `ff1-cli`.
+This document defines the current product role, boundaries, and constraints for `ff-cli`.
 
 It is derived from the behavior and interfaces implemented in this repository as of March 2026. It serves as the planning entry point for substantial changes and should be updated as the CLI evolves.
 
@@ -12,12 +12,12 @@ It is derived from the behavior and interfaces implemented in this repository as
 
 ## Product summary
 
-- Project: `ff1-cli`
+- Project: `ff-cli`
 - Type: Node.js CLI
 - System role: a control and integration surface for FF1 and DP-1 workflows
 - Primary purpose: turn user intent or structured parameters into valid DP-1 playlists, then validate them and optionally sign, publish, and send them through FF1 and feed paths
 
-In the Feral File architecture bands, `ff1-cli` sits primarily in the presentation and control layer. It is not the canonical source of truth for exhibitions, ownership, device runtime, or protocol evolution. It is a practical operator and developer surface that bridges those systems.
+In the Feral File architecture bands, `ff-cli` sits primarily in the presentation and control layer. It is not the canonical source of truth for exhibitions, ownership, device runtime, or protocol evolution. It is a practical operator and developer surface that bridges those systems.
 
 ## Strategic role
 
@@ -87,7 +87,7 @@ Long-term interoperability should continue to reduce hard infrastructure couplin
 
 ## Non-goals
 
-`ff1-cli` should not become:
+`ff-cli` should not become:
 
 - the source of truth for exhibitions, channels, or artwork metadata
 - the source of truth for ownership, passkeys, rights, or trust registry state

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# FF1-CLI Documentation
+# ff-cli Documentation
 
 Build DP-1 (Display Protocol 1) playlists from NFT data with either natural language (AI‑driven) or deterministic parameters. This doc covers install, config, and day‑to‑day usage.
 
@@ -7,7 +7,7 @@ For project-level planning and future agentic work, see `./PROJECT_SPEC.md`.
 ## Install
 
 ```bash
-npm i -g ff1-cli
+npm i -g ff-cli
 ```
 
 `npm` and `npx` require **Node.js 22 or newer** (see `package.json` `engines`). When a release raises the Node floor, that is a **breaking** change for Node 18/20 users; the GitHub Release for that version should say so explicitly (see `./RELEASING.md` for maintainer guidance).
@@ -15,7 +15,7 @@ npm i -g ff1-cli
 ## Install (curl)
 
 ```bash
-curl -fsSL https://feralfile.com/ff1-cli-install | bash
+curl -fsSL https://feralfile.com/ff-cli-install | bash
 ```
 
 Installs a prebuilt binary for macOS/Linux (no Node.js required).
@@ -24,18 +24,18 @@ Installs a prebuilt binary for macOS/Linux (no Node.js required).
 
 ```bash
 # Guided setup (recommended)
-ff1 setup
+ff-cli setup
 ```
 
 See the full configuration reference here: `./CONFIGURATION.md`.
 
-During setup, you can pick FF1 devices to add. Use `ff1 device add` to add more devices later, and `ff1 device list` to see what's configured. The first device is the default for `play` commands (override with `-d`).
+During setup, you can pick FF1 devices to add. Use `ff-cli device add` to add more devices later, and `ff-cli device list` to see what's configured. The first device is the default for `play` commands (override with `-d`).
 
 Manual config path:
 
 ```bash
-ff1 config init
-ff1 config validate
+ff-cli config init
+ff-cli config validate
 ```
 
 ### config.json structure (minimal)
@@ -87,13 +87,13 @@ See `./CONFIGURATION.md` for environment variable mappings.
 
 ```bash
 # Chat
-ff1 chat
+ff-cli chat
 
 # Or natural language in one shot
-ff1 chat "Get 3 works from reas.eth" -o playlist.json
+ff-cli chat "Get 3 works from reas.eth" -o playlist.json
 
 # Deterministic (no AI)
-ff1 build examples/params-example.json -o playlist.json
+ff-cli build examples/params-example.json -o playlist.json
 ```
 
 For development in this repo:
@@ -192,8 +192,8 @@ The intent parser recognizes publishing keywords and can both display and publis
 # Build and publish
 npm run dev -- chat "Build playlist from Ethereum contract 0xb932a70A57673d89f4acfFBE830E8ed7f75Fb9e0 with tokens 52932 and 52457; publish to my feed" -o playlist.json -v
 
-# Display on FF1 AND publish to feed
-npm run dev -- chat "Get 3 from Unsupervised; shuffle; send to my FF1 and publish to feed" -o playlist.json -v
+# Display on Art Computer AND publish to feed
+npm run dev -- chat "Get 3 from Unsupervised; shuffle; send to my Art Computer and publish to feed" -o playlist.json -v
 ```
 
 For Feral File built playlists, you can reference titles listed in the repository:
@@ -258,12 +258,12 @@ npm run dev -- play playlist.json --skip-verify
 
 ```bash
 # Enable SSH access for 30 minutes
-ff1 ssh enable --pubkey ~/.ssh/id_ed25519.pub --ttl 30m -d "Living Room Display"
+ff-cli ssh enable --pubkey ~/.ssh/id_ed25519.pub --ttl 30m -d "Living Room Display"
 
 # Disable SSH access
-ff1 ssh disable -d "Living Room Display"
+ff-cli ssh disable -d "Living Room Display"
 
-# `ff1 ssh` also performs the same FF1 OS compatibility preflight used by `play`.
+# `ff-cli ssh` also performs the same FF1 OS compatibility preflight used by `play`.
 ```
 
 ### Publish to feed server
@@ -305,19 +305,19 @@ Configure feed servers in `config.json`:
 
 ```bash
 # List configured devices
-ff1 device list
+ff-cli device list
 
 # Add a device (interactive with mDNS discovery)
-ff1 device add
+ff-cli device add
 
 # Add a device non-interactively
-ff1 device add --host 192.168.1.100 --name kitchen
+ff-cli device add --host 192.168.1.100 --name kitchen
 
 # Remove a device by name
-ff1 device remove kitchen
+ff-cli device remove kitchen
 
 # Set the default device (used when -d is omitted)
-ff1 device default office
+ff-cli device default office
 ```
 
 Setup preserves existing devices when adding new ones. See selection rules and examples in `./CONFIGURATION.md`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,9 +18,9 @@ The curl installer downloads prebuilt binaries from GitHub Releases. Build one a
 
 This produces (names vary by OS/arch):
 
-- `release/ff1-cli-darwin-arm64.tar.gz` (and `.sha256`) on macOS
-- `release/ff1-cli-linux-x64.tar.gz` (and `.sha256`) on Linux
-- `release/ff1-cli-windows-x64.zip` (and `.sha256`) on Windows
+- `release/ff-cli-darwin-arm64.tar.gz` (and `.sha256`) on macOS
+- `release/ff-cli-linux-x64.tar.gz` (and `.sha256`) on Linux
+- `release/ff-cli-windows-x64.zip` (and `.sha256`) on Windows
 
 Run the appropriate script on each target platform and upload each pair to the GitHub release.
 
@@ -42,28 +42,28 @@ GitHub Release text (and any user-facing summary you publish with the version) s
 
 `package.json` declares `"engines": { "node": ">=22" }`. Raising the floor from Node 18 (or 20) is a **breaking change** for:
 
-- global installs and `npx ff1-cli` on older runtimes
+- global installs and `npx ff-cli` on older runtimes
 - CI jobs and images pinned to Node 18 or 20
 - anyone developing from source without upgrading Node
 
 **For the release that first ships this requirement**, copy or adapt the following into the GitHub Release description (and repeat in the upgrade section of internal comms if needed):
 
-> **Breaking — Node.js:** ff1-cli now requires **Node.js 22 or newer** (`package.json` `engines`). Node 18 and Node 20 are no longer supported. Upgrade Node on your machines and in CI, or stay on an older ff1-cli version until you can migrate.
+> **Breaking — Node.js:** ff-cli now requires **Node.js 22 or newer** (`package.json` `engines`). Node 18 and Node 20 are no longer supported. Upgrade Node on your machines and in CI, or stay on an older ff-cli version until you can migrate.
 
 Later releases only need to repeat this block if the engine floor changes again.
 
 ## Installer Redirect
 
-`https://feralfile.com/ff1-cli-install` should redirect to:
+`https://feralfile.com/ff-cli-install` should redirect to:
 
 ```
-https://raw.githubusercontent.com/feral-file/ff1-cli/main/scripts/install.sh
+https://raw.githubusercontent.com/feral-file/ff-cli/main/scripts/install.sh
 ```
 
 The installer script then fetches the release assets from GitHub Releases.
 
 ## Environment Overrides
 
-- `FF1_CLI_VERSION`: overrides the version label in logs
-- `FF1_CLI_NODE_VERSION`: Reserved in script headers for future use; current CI, npm `engines`, and release wrappers assume **Node.js 22+** (required by `dp1-js`).
-- `FF1_CLI_OUTPUT_DIR`: output directory (default: `./release`)
+- `FF_CLI_VERSION`: overrides the version label in logs
+- `FF_CLI_NODE_VERSION`: Reserved in script headers for future use; current CI, npm `engines`, and release wrappers assume **Node.js 22+** (required by `dp1-js`).
+- `FF_CLI_OUTPUT_DIR`: output directory (default: `./release`)

--- a/examples/openclaw-ff-skill.md
+++ b/examples/openclaw-ff-skill.md
@@ -1,36 +1,36 @@
-# OpenClaw Skill: FF1
+# OpenClaw Skill: Art Computer
 
-Canonical skill file: `skills/ff1-control/SKILL.md`
+Canonical skill file: `skills/ff-control/SKILL.md`
 
 Use this copy if your OpenClaw setup expects a single markdown prompt.
 
 ```text
-You run ff1-cli end to end with full autonomy.
+You run ff-cli end to end with full autonomy.
 Do not ask for final confirmation before send or publish.
 
 Context:
-- FF1 is Feral File's art computer in The Digital Art System.
-- This skill uses ff1-cli to build DP-1 playlists and send/publish them.
+- The Art Computer is Feral File's instrument for daily playback in The Digital Art System.
+- This skill uses ff-cli to build DP-1 playlists and send/publish them.
 - Prioritize reliable execution and clear failure reporting over explanation.
 
 Keep it simple. Prefer deletion over added process.
 Do not invent new requirements.
 
 Flow:
-1) ff1 status
-2) ff1 config validate
+1) ff-cli status
+2) ff-cli config validate
 3) Build playlist:
-   - use `ff1 chat "<request>" -o playlist.json -v`
-   - or `ff1 build <params.json> -o playlist.json -v` when params are already structured
-4) `ff1 validate playlist.json`
+   - use `ff-cli chat "<request>" -o playlist.json -v`
+   - or `ff-cli build <params.json> -o playlist.json -v` when params are already structured
+4) `ff-cli validate playlist.json`
 5) If requested, run:
-   - send: `ff1 send playlist.json` (or with `-d "Device Name"`)
+   - send: `ff-cli send playlist.json` (or with `-d "Device Name"`)
    - if send fails with reachability errors (`fetch failed`, `No route to host`, resolver timeout), try one automatic host-shell fallback:
-     `ssh -o BatchMode=yes -o ConnectTimeout=5 localhost "cd ~/.openclaw/workspace && ff1 send playlist.json -d <device>"`
+     `ssh -o BatchMode=yes -o ConnectTimeout=5 localhost "cd ~/.openclaw/workspace && ff-cli send playlist.json -d <device>"`
    - if fallback succeeds, report success and stop
-   - if fallback fails, print exactly one handoff line and nothing else: `RUN_LOCAL: ff1 send playlist.json -d <device>`
+   - if fallback fails, print exactly one handoff line and nothing else: `RUN_LOCAL: ff-cli send playlist.json -d <device>`
    - do not suggest tunnels, IP changes, network debugging, or extra steps
-   - publish: `ff1 publish playlist.json`
+   - publish: `ff-cli publish playlist.json`
    - if both are requested: send first, then publish
 
 If any step fails, do not hide it.

--- a/index.ts
+++ b/index.ts
@@ -37,14 +37,14 @@ const { version: packageVersion } = JSON.parse(readFileSync(packageJsonPath, 'ut
 const program = new Command();
 
 program
-  .name('ff1')
+  .name('ff-cli')
   .description(
     'CLI to fetch NFT information and build DP1 playlists using AI (Grok, ChatGPT, Gemini)'
   )
   .version(packageVersion)
   .addHelpText(
     'after',
-    `\nQuick start:\n  1) ff1 setup\n  2) ff1 chat\n\nDocs: https://github.com/feralfile/ff1-cli\n`
+    `\nQuick start:\n  1) ff-cli setup\n  2) ff-cli chat\n\nDocs: https://github.com/feral-file/ff-cli\n`
   );
 
 program.addCommand(setupCommand);

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,7 @@
   "instructions": ["AGENTS.md"],
   "agent": {
     "reviewer": {
-      "description": "Read-only code reviewer for FF1-CLI. Use after implementation for a fresh-context review of the diff and verification output.",
+      "description": "Read-only code reviewer for ff-cli. Use after implementation for a fresh-context review of the diff and verification output.",
       "mode": "subagent",
       "prompt": "{file:./prompts/code-review.md}",
       "tools": {
@@ -14,7 +14,7 @@
   },
   "command": {
     "review": {
-      "description": "Run a fresh-context FF1-CLI code review using the shared review contract",
+      "description": "Run a fresh-context ff-cli code review using the shared review contract",
       "template": "Review the current changes using the contract in prompts/code-review.md.\n\nUse this evidence:\n- Diff stat: !`git diff --stat`\n- Full diff: !`git diff`\n- Verification: run or paste relevant lint, test, build, and smoke-test output.\n\nIf a handoff was provided, use it as context. Report findings in the required format and end with Verdict: accept or Verdict: revise. Do not edit files unless explicitly asked.",
       "agent": "reviewer",
       "subtask": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ff1-cli",
+  "name": "ff-cli",
   "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ff1-cli",
+      "name": "ff-cli",
       "version": "1.0.17",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "ff1-cli",
+  "name": "ff-cli",
   "version": "1.0.17",
   "description": "CLI to fetch NFT information and build DP1 playlists using Grok API",
   "main": "dist/index.js",
   "bin": {
-    "ff1": "dist/index.js"
+    "ff-cli": "dist/index.js"
   },
   "files": [
     "dist",

--- a/prompts/code-review.md
+++ b/prompts/code-review.md
@@ -1,4 +1,4 @@
-# FF1-CLI Code Review Contract
+# ff-cli Code Review Contract
 
 Use this contract for fresh-context review after implementation.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="feral-file/ff1-cli"
-INSTALL_DIR_DEFAULT="$HOME/.local/ff1-cli"
+REPO="feral-file/ff-cli"
+INSTALL_DIR_DEFAULT="$HOME/.local/ff-cli"
 BIN_DIR_DEFAULT="$HOME/.local/bin"
 
-INSTALL_DIR="${FF1_CLI_INSTALL_DIR:-$INSTALL_DIR_DEFAULT}"
-BIN_DIR="${FF1_CLI_BIN_DIR:-$BIN_DIR_DEFAULT}"
-VERSION="${FF1_CLI_VERSION:-latest}"
-BASE_URL="${FF1_CLI_BASE_URL:-https://github.com/$REPO/releases}"
+INSTALL_DIR="${FF_CLI_INSTALL_DIR:-$INSTALL_DIR_DEFAULT}"
+BIN_DIR="${FF_CLI_BIN_DIR:-$BIN_DIR_DEFAULT}"
+VERSION="${FF_CLI_VERSION:-latest}"
+BASE_URL="${FF_CLI_BASE_URL:-https://github.com/$REPO/releases}"
 
 OS_RAW="$(uname -s)"
 ARCH_RAW="$(uname -m)"
@@ -21,7 +21,7 @@ case "$OS_RAW" in
     OS="linux"
     ;;
   *)
-    echo "ff1-cli installer: unsupported OS: $OS_RAW"
+    echo "ff-cli installer: unsupported OS: $OS_RAW"
     exit 1
     ;;
 esac
@@ -34,12 +34,12 @@ case "$ARCH_RAW" in
     ARCH="arm64"
     ;;
   *)
-    echo "ff1-cli installer: unsupported architecture: $ARCH_RAW"
+    echo "ff-cli installer: unsupported architecture: $ARCH_RAW"
     exit 1
     ;;
 esac
 
-ASSET="ff1-cli-$OS-$ARCH.tar.gz"
+ASSET="ff-cli-$OS-$ARCH.tar.gz"
 CHECKSUM="$ASSET.sha256"
 
 if [ "$VERSION" = "latest" ]; then
@@ -56,7 +56,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "Downloading ff1-cli ($OS/$ARCH)..."
+echo "Downloading ff-cli ($OS/$ARCH)..."
 curl -fsSL "$DOWNLOAD_URL" -o "$WORKDIR/$ASSET"
 curl -fsSL "$CHECKSUM_URL" -o "$WORKDIR/$CHECKSUM"
 
@@ -65,18 +65,18 @@ if command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   (cd "$WORKDIR" && shasum -a 256 -c "$CHECKSUM")
 else
-  echo "ff1-cli installer: missing sha256sum/shasum for verification."
+  echo "ff-cli installer: missing sha256sum/shasum for verification."
   exit 1
 fi
 
 mkdir -p "$INSTALL_DIR" "$BIN_DIR"
 tar -xzf "$WORKDIR/$ASSET" -C "$INSTALL_DIR" --strip-components=1
 
-ln -sf "$INSTALL_DIR/bin/ff1" "$BIN_DIR/ff1"
+ln -sf "$INSTALL_DIR/bin/ff-cli" "$BIN_DIR/ff-cli"
 
-if ! command -v ff1 >/dev/null 2>&1; then
-  echo "Installed ff1 to $BIN_DIR, but it is not on your PATH."
+if ! command -v ff-cli >/dev/null 2>&1; then
+  echo "Installed ff-cli to $BIN_DIR, but it is not on your PATH."
   echo "Add this to your shell profile: export PATH=\"$BIN_DIR:\$PATH\""
 else
-  echo "ff1-cli installed. Run: ff1 --help"
+  echo "ff-cli installed. Run: ff-cli --help"
 fi

--- a/scripts/release/build-asset-windows.ps1
+++ b/scripts/release/build-asset-windows.ps1
@@ -1,5 +1,5 @@
-# Build Windows release asset: ff1-cli-windows-x64.zip and .sha256
-# Run from repo root or scripts/release. Uses env: FF1_CLI_OUTPUT_DIR, FF1_CLI_NODE_VERSION, FF1_CLI_VERSION.
+# Build Windows release asset: ff-cli-windows-x64.zip and .sha256
+# Run from repo root or scripts/release. Uses env: FF_CLI_OUTPUT_DIR, FF_CLI_NODE_VERSION, FF_CLI_VERSION.
 
 $ErrorActionPreference = "Stop"
 Add-Type -AssemblyName System.IO.Compression
@@ -69,19 +69,19 @@ function New-ZipArchiveWithProgress {
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ROOT_DIR = (Resolve-Path (Join-Path $ScriptDir "../..")).Path
-$OUTPUT_DIR = if ($env:FF1_CLI_OUTPUT_DIR) { $env:FF1_CLI_OUTPUT_DIR } else { Join-Path $ROOT_DIR "release" }
-$VERSION = if ($env:FF1_CLI_VERSION) { $env:FF1_CLI_VERSION } else {
+$OUTPUT_DIR = if ($env:FF_CLI_OUTPUT_DIR) { $env:FF_CLI_OUTPUT_DIR } else { Join-Path $ROOT_DIR "release" }
+$VERSION = if ($env:FF_CLI_VERSION) { $env:FF_CLI_VERSION } else {
     (Get-Content (Join-Path $ROOT_DIR "package.json") | ConvertFrom-Json).version
 }
 
 $OS = "windows"
 $ARCH = "x64"
-$ASSET_NAME = "ff1-cli-$OS-$ARCH"
+$ASSET_NAME = "ff-cli-$OS-$ARCH"
 $ARCHIVE_NAME = "$ASSET_NAME.zip"
 
 $WORKDIR = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_.FullName }
 try {
-    Write-Host "Building ff1-cli bundle..."
+    Write-Host "Building ff-cli bundle..."
     Set-Location $ROOT_DIR
     npm ci
     npm run bundle
@@ -90,14 +90,14 @@ try {
     New-Item -ItemType Directory -Path (Join-Path $PACKAGE_DIR "bin") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $PACKAGE_DIR "lib") -Force | Out-Null
 
-    Copy-Item (Join-Path $ROOT_DIR "dist\ff1.js") (Join-Path $PACKAGE_DIR "lib\ff1.js")
+    Copy-Item (Join-Path $ROOT_DIR "dist\ff-cli.js") (Join-Path $PACKAGE_DIR "lib\ff-cli.js")
     Copy-Item (Join-Path $ROOT_DIR "package.json") (Join-Path $PACKAGE_DIR "package.json")
     Copy-Item (Join-Path $ROOT_DIR "LICENSE") (Join-Path $PACKAGE_DIR "LICENSE")
 
-    $ff1Cmd = @"
+    $ffCliCmd = @"
 @echo off
 set "BASE_DIR=%~dp0.."
-set "APP=%BASE_DIR%\lib\ff1.js"
+set "APP=%BASE_DIR%\lib\ff-cli.js"
 where node >nul 2>nul
 if errorlevel 1 (
   echo Node.js 22+ is required. Install Node.js, then run this command again.
@@ -105,7 +105,7 @@ if errorlevel 1 (
 )
 node "%APP%" %*
 "@
-    [System.IO.File]::WriteAllText((Join-Path $PACKAGE_DIR "bin\ff1.cmd"), $ff1Cmd)
+    [System.IO.File]::WriteAllText((Join-Path $PACKAGE_DIR "bin\ff-cli.cmd"), $ffCliCmd)
 
     $requirements = @"
 Runtime requirement:
@@ -115,7 +115,7 @@ Verify:
 - node -v
 
 Run:
-- .\bin\ff1.cmd --help
+- .\bin\ff-cli.cmd --help
 "@
     [System.IO.File]::WriteAllText((Join-Path $PACKAGE_DIR "RUNTIME_REQUIREMENTS.txt"), $requirements)
 

--- a/scripts/release/build-asset.sh
+++ b/scripts/release/build-asset.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-OUTPUT_DIR="${FF1_CLI_OUTPUT_DIR:-$ROOT_DIR/release}"
-VERSION="${FF1_CLI_VERSION:-$(node -p "require('$ROOT_DIR/package.json').version")}"
+OUTPUT_DIR="${FF_CLI_OUTPUT_DIR:-$ROOT_DIR/release}"
+VERSION="${FF_CLI_VERSION:-$(node -p "require('$ROOT_DIR/package.json').version")}"
 
 OS_RAW="$(uname -s)"
 ARCH_RAW="$(uname -m)"
@@ -34,7 +34,7 @@ case "$ARCH_RAW" in
     ;;
 esac
 
-ASSET_NAME="ff1-cli-$OS-$ARCH"
+ASSET_NAME="ff-cli-$OS-$ARCH"
 ARCHIVE_NAME="$ASSET_NAME.tar.gz"
 
 WORKDIR="$(mktemp -d)"
@@ -43,7 +43,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "Building ff1-cli bundle..."
+echo "Building ff-cli bundle..."
 cd "$ROOT_DIR"
 npm ci
 npm run bundle
@@ -51,15 +51,15 @@ npm run bundle
 PACKAGE_DIR="$WORKDIR/$ASSET_NAME"
 mkdir -p "$PACKAGE_DIR/bin" "$PACKAGE_DIR/lib"
 
-cp "$ROOT_DIR/dist/ff1.js" "$PACKAGE_DIR/lib/ff1.js"
+cp "$ROOT_DIR/dist/ff-cli.js" "$PACKAGE_DIR/lib/ff-cli.js"
 cp "$ROOT_DIR/package.json" "$PACKAGE_DIR/package.json"
 cp "$ROOT_DIR/LICENSE" "$PACKAGE_DIR/LICENSE"
 
-cat > "$PACKAGE_DIR/bin/ff1" <<'EOF'
+cat > "$PACKAGE_DIR/bin/ff-cli" <<'EOF'
 #!/usr/bin/env bash
 set -e
 BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-APP="$BASE_DIR/lib/ff1.js"
+APP="$BASE_DIR/lib/ff-cli.js"
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js 22+ is required. Install Node.js, then run this command again."
   exit 1
@@ -67,7 +67,7 @@ fi
 exec node "$APP" "$@"
 EOF
 
-chmod +x "$PACKAGE_DIR/bin/ff1"
+chmod +x "$PACKAGE_DIR/bin/ff-cli"
 
 cat > "$PACKAGE_DIR/RUNTIME_REQUIREMENTS.txt" <<'EOF'
 Runtime requirement:
@@ -77,7 +77,7 @@ Verify:
 - node -v
 
 Run:
-- ./bin/ff1 --help
+- ./bin/ff-cli --help
 EOF
 
 mkdir -p "$OUTPUT_DIR"

--- a/skills/ff-control/SKILL.md
+++ b/skills/ff-control/SKILL.md
@@ -1,29 +1,29 @@
-You run ff1-cli end to end with full autonomy.
+You run ff-cli end to end with full autonomy.
 Do not ask for final confirmation before send or publish.
 
 Context:
-- FF1 is Feral File's art computer in The Digital Art System.
-- This skill uses ff1-cli to build DP-1 playlists and send/publish them.
+- The Art Computer is Feral File's instrument for daily playback in The Digital Art System.
+- This skill uses ff-cli to build DP-1 playlists and send/publish them.
 - Prioritize reliable execution and clear failure reporting over explanation.
 
 Keep it simple. Prefer deletion over added process.
 Do not invent new requirements.
 
 Flow:
-1) ff1 status
-2) ff1 config validate
+1) ff-cli status
+2) ff-cli config validate
 3) Build playlist:
-   - use `ff1 chat "<request>" -o playlist.json -v`
-   - or `ff1 build <params.json> -o playlist.json -v` when params are already structured
-4) `ff1 validate playlist.json`
+   - use `ff-cli chat "<request>" -o playlist.json -v`
+   - or `ff-cli build <params.json> -o playlist.json -v` when params are already structured
+4) `ff-cli validate playlist.json`
 5) If requested, run:
-   - send: `ff1 send playlist.json` (or with `-d "Device Name"`)
+   - send: `ff-cli send playlist.json` (or with `-d "Device Name"`)
    - if send fails with reachability errors (`fetch failed`, `No route to host`, resolver timeout), try one automatic host-shell fallback:
-     `ssh -o BatchMode=yes -o ConnectTimeout=5 localhost "cd ~/.openclaw/workspace && ff1 send playlist.json -d <device>"`
+     `ssh -o BatchMode=yes -o ConnectTimeout=5 localhost "cd ~/.openclaw/workspace && ff-cli send playlist.json -d <device>"`
    - if fallback succeeds, report success and stop
-   - if fallback fails, print exactly one handoff line and nothing else: `RUN_LOCAL: ff1 send playlist.json -d <device>`
+   - if fallback fails, print exactly one handoff line and nothing else: `RUN_LOCAL: ff-cli send playlist.json -d <device>`
    - do not suggest tunnels, IP changes, network debugging, or extra steps
-   - publish: `ff1 publish playlist.json`
+   - publish: `ff-cli publish playlist.json`
    - if both are requested: send first, then publish
 
 If any step fails, do not hide it.

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -165,13 +165,13 @@ export const setupCommand = new Command('setup')
           ? existingDevices.findIndex((d) => d === existingEntry)
           : -1;
         const existingName = existingEntry?.name || '';
-        const defaultName = existingName || selection.discoveredName || 'ff1';
+        const defaultName = existingName || selection.discoveredName || 'art-computer';
         const namePrompt =
-          defaultName !== 'ff1'
+          defaultName !== 'art-computer'
             ? `Device name (kitchen, office, etc.) [${defaultName}]: `
             : 'Device name (kitchen, office, etc.): ';
         const nameAnswer = await ask(namePrompt);
-        let deviceName = nameAnswer || defaultName || 'ff1';
+        let deviceName = nameAnswer || defaultName || 'art-computer';
 
         // Same name-collision guard as `device add`: reject names that would
         // clobber a different device entry. Only fires when existingIndex !== -1
@@ -188,7 +188,7 @@ export const setupCommand = new Command('setup')
             )
           );
           const retryAnswer = await ask('Device name: ');
-          deviceName = retryAnswer || 'ff1';
+          deviceName = retryAnswer || 'art-computer';
           const retryConflict =
             existingIndex !== -1
               ? existingDevices.find((d, i) => d.name === deviceName && i !== existingIndex)
@@ -238,10 +238,10 @@ export const setupCommand = new Command('setup')
         }
       }
       if (!hasApiKey) {
-        console.log(chalk.dim(`\nTo use ff1 chat, add an API key for ${selectedModel}`));
+        console.log(chalk.dim(`\nTo use ff-cli chat, add an API key for ${selectedModel}`));
       }
 
-      console.log(chalk.dim('\nRun: ff1 play'));
+      console.log(chalk.dim('\nRun: ff-cli play'));
     } catch (error) {
       console.error(chalk.red('\nSetup failed:'), (error as Error).message);
       process.exit(1);

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,10 +15,43 @@ import {
   resolveDp1PlaylistSigningRole,
 } from './utilities/playlist-signing-role';
 
+// One-shot legacy config migration: copy `$XDG_CONFIG_HOME/ff1/config.json` to
+// `$XDG_CONFIG_HOME/ff-cli/config.json` on first read after upgrading from
+// `ff1-cli`. The check is cheap (two fs.existsSync calls) and the
+// `migrationChecked` flag keeps it to one attempt per process.
+//
+// Remove this block after a release cycle once telemetry suggests no remaining
+// users still have only the legacy path populated.
+let migrationChecked = false;
+
+function migrateLegacyConfigIfNeeded(newUserPath: string): void {
+  if (migrationChecked) {
+    return;
+  }
+  migrationChecked = true;
+
+  const configBase = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  const legacyUserPath = path.join(configBase, 'ff1', 'config.json');
+
+  if (!fs.existsSync(legacyUserPath) || fs.existsSync(newUserPath)) {
+    return;
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(newUserPath), { recursive: true });
+    fs.copyFileSync(legacyUserPath, newUserPath);
+    console.log(`Migrated config from ${legacyUserPath} to ${newUserPath}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Warning: Failed to migrate legacy config from ${legacyUserPath}: ${message}`);
+  }
+}
+
 export function getConfigPaths(): { localPath: string; userPath: string } {
   const localPath = path.join(process.cwd(), 'config.json');
   const configBase = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
-  const userPath = path.join(configBase, 'ff1', 'config.json');
+  const userPath = path.join(configBase, 'ff-cli', 'config.json');
+  migrateLegacyConfigIfNeeded(userPath);
   return { localPath, userPath };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for FF1-CLI
+ * Type definitions for ff-cli
  */
 
 export interface ModelConfig {

--- a/tests/chat-device-routing.test.ts
+++ b/tests/chat-device-routing.test.ts
@@ -191,7 +191,7 @@ describe('buildPlaylistWithAI orchestrator --device fallback', () => {
   }
 
   // Regression: before fix, defaultDeviceName was never forwarded to buildPlaylistWithAI,
-  // so `ff1 chat --device kitchen "build X and send"` dropped the kitchen target when the
+  // so `ff-cli chat --device kitchen "build X and send"` dropped the kitchen target when the
   // model emitted deviceName: null (send intent present, no device in text).
   test('uses CLI --device when intent parser emits null deviceName (send intent, no device in text)', () => {
     assert.equal(resolveOrchestratorDevice(null, 'kitchen'), 'kitchen');

--- a/tests/cli-sign-verify.test.ts
+++ b/tests/cli-sign-verify.test.ts
@@ -60,7 +60,7 @@ function runCli(
 }
 
 function makeWorkspace(): string {
-  return mkdtempSync(join(tmpdir(), 'ff1-cli-integration-'));
+  return mkdtempSync(join(tmpdir(), 'ff-cli-integration-'));
 }
 
 function writeSigningConfig(dir: string): void {

--- a/tests/play-source.test.ts
+++ b/tests/play-source.test.ts
@@ -27,7 +27,7 @@ describe('resolvePlaySource', () => {
   let tmp: string;
 
   before(() => {
-    tmp = mkdtempSync(join(tmpdir(), 'ff1-play-source-'));
+    tmp = mkdtempSync(join(tmpdir(), 'ff-cli-play-source-'));
   });
 
   after(() => {


### PR DESCRIPTION
## Summary

Renames the project, binary, and npm package from `ff1-cli` to `ff-cli`. The CLI talks to the Art Computer (and any future hardware on the same DP-1 protocol), so the model designation in the tool name no longer fits. FF1 stays as the engineering handle for the device itself.

## Behavior changes that users will feel

- **Binary renamed.** Type `ff-cli` instead of `ff1` (Commander `.name`, help text, completions).
- **npm package renamed.** `npm i -g ff-cli` (was `ff1-cli`).
- **Install URL renamed.** `https://feralfile.com/ff-cli-install` (was `ff1-cli-install`). **The feralfile.com redirect needs to be updated to point at the new GitHub raw URL before release** — `docs/RELEASING.md` documents the new target.
- **Release asset names renamed.** `ff-cli-darwin-arm64.tar.gz` (was `ff1-cli-*`). Release workflow + checksum verification updated.
- **Env vars renamed.** `FF_CLI_VERSION`, `FF_CLI_OUTPUT_DIR`, `FF_CLI_INSTALL_DIR`, etc. (was `FF1_CLI_*`).
- **Default device name at setup.** Suggested label changed from `ff1` to `art-computer` in the setup prompt.
- **User config path.** Moved to `$XDG_CONFIG_HOME/ff-cli/config.json`. A one-shot migration in `src/config.ts` copies the legacy `ff1/config.json` to the new path on first run so existing users keep their API keys and Ed25519 signing keys. Migration block is clearly marked for removal after a release cycle.

## What stays as FF1

Per the rule "engineering identifiers stay when the text is about a specific model":

- `FF1Device`, `FF1DeviceConfig` types
- `src/utilities/ff1-device.ts`, `ff1-compatibility.ts`, `ff1-discovery.ts` paths
- `ff1Devices` config schema key
- `_ff1._tcp` mDNS service identifier
- `FF1 device`, `FF1 OS`, `FF1 OS version`, `FF1 SSH` in spec and configuration docs (`docs/PROJECT_SPEC.md` §Domain language, `docs/CONFIGURATION.md` device sections)

## Skill / OpenClaw

`skills/ff1-control/` and `examples/openclaw-ff1-skill.md` renamed to `skills/ff-control/` and `openclaw-ff-skill.md`. The skill is for the CLI tool, not the model, so it follows the new tool name.

## Cross-repo references

Canon (`feral-file/canon`) is being updated in a separate commit to point at `feral-file/ff-cli` in `arch/repo-overview.md` and `ops/factory-map.md`.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — **231/231 pass** (was incorrectly failing in earlier local runs due to a stale `node_modules`; `npm ci` resolved it)
- [x] `npm run smoke` — playlist validate + config validate pass
- [ ] CI: lint, build, codeql, dependency-review
- [ ] After merge: rename GitHub repo `feral-file/ff1-cli` → `feral-file/ff-cli` via repo Settings
- [ ] After merge: update `feralfile.com/ff-cli-install` redirect to `https://raw.githubusercontent.com/feral-file/ff-cli/main/scripts/install.sh`
- [ ] After merge: publish next npm release as `ff-cli@<version>` (note: this is a new package on npm; `ff1-cli` will stop receiving updates)

## Follow-ups (not in this PR)

- Local repo dir `~/Work/ff1-cli` → `~/Work/ff-cli` rename (mosko's machine; doesn't affect anyone else)
- Sunset / deprecation notice on the old `ff1-cli` npm package (point users to `ff-cli`)