### PR TITLE
chore: rename npm package to @feralfile/cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           SLEEP_SECONDS=10
 
           for attempt in $(seq 1 "$ATTEMPTS"); do
-            NPM_VERSION=$(npm view ff-cli dist-tags.beta)
+            NPM_VERSION=$(npm view @feralfile/cli dist-tags.beta)
             if [ "$NPM_VERSION" = "$EXPECTED_VERSION" ]; then
               echo "npm beta dist-tag check passed: $NPM_VERSION"
               exit 0
@@ -236,9 +236,9 @@ jobs:
           SLEEP_SECONDS=10
 
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            NPM_QUERY="npm view ff-cli dist-tags.beta"
+            NPM_QUERY="npm view @feralfile/cli dist-tags.beta"
           else
-            NPM_QUERY="npm view ff-cli version"
+            NPM_QUERY="npm view @feralfile/cli version"
           fi
 
           for attempt in $(seq 1 "$ATTEMPTS"); do

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ff-cli turns a simple prompt into a DP-1–conformant playlist you can preview o
 ## Install
 
 ```bash
-npm i -g ff-cli
+npm i -g @feralfile/cli
 ```
 
 ## Install (curl)
@@ -23,8 +23,8 @@ Installs a prebuilt binary for macOS/Linux (no Node.js required).
 ## One-off Usage (npx)
 
 ```bash
-npx ff-cli setup
-npx ff-cli chat
+npx @feralfile/cli setup
+npx @feralfile/cli chat
 ```
 
 ## Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ For project-level planning and future agentic work, see `./PROJECT_SPEC.md`.
 ## Install
 
 ```bash
-npm i -g ff-cli
+npm i -g @feralfile/cli
 ```
 
 `npm` and `npx` require **Node.js 22 or newer** (see `package.json` `engines`). When a release raises the Node floor, that is a **breaking** change for Node 18/20 users; the GitHub Release for that version should say so explicitly (see `./RELEASING.md` for maintainer guidance).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,7 +46,7 @@ GitHub Release text (and any user-facing summary you publish with the version) s
 
 `package.json` declares `"engines": { "node": ">=22" }`. Raising the floor from Node 18 (or 20) is a **breaking change** for:
 
-- global installs and `npx ff-cli` on older runtimes
+- global installs and `npx @feralfile/cli` on older runtimes
 - CI jobs and images pinned to Node 18 or 20
 - anyone developing from source without upgrading Node
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ff-cli",
+  "name": "@feralfile/cli",
   "version": "1.0.17",
   "description": "CLI to fetch NFT information and build DP1 playlists using Grok API",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Unscoped `ff-cli` on npm is owned by an unrelated package (a Solana CLI), so the rename PR's `name: ff-cli` can't actually publish. Switch to the `@feralfile` scope (now claimed on npmjs.com) so we can publish under the Feral File namespace.
- The on-PATH binary stays `ff-cli` (controlled by `package.json` `bin`, independent of package name).
- Pattern mirrors `@vercel/cli`, `@angular/cli`, `@nestjs/cli`, `@aws-amplify/cli`.

## Changes
- `package.json`: `name` → `@feralfile/cli`
- `.github/workflows/release.yml`: `npm view ff-cli ...` → `npm view @feralfile/cli ...` (both verify steps)
- `README.md`, `docs/README.md`: `npm i -g ff-cli` → `npm i -g @feralfile/cli`; same for the `npx` examples
- `docs/RELEASING.md`: `npx ff-cli` reference

## Follow-up after merge + first release
Deprecate the old unscoped name (Sean to run, logged in as `dev@feralfile.com`):

```
npm deprecate "ff1-cli@*" "Renamed to @feralfile/cli. Install: npm install -g @feralfile/cli  (or curl -fsSL https://feralfile.com/ff-cli-install | bash)"
```

## Test plan
- [ ] CI green (release.yml verify-version path, ci.yml lint/test)
- [ ] After merge + tag, `Release` workflow publishes `@feralfile/cli` successfully to npm under the new scope
- [ ] `npm view @feralfile/cli version` returns the tagged version
- [ ] `npm i -g @feralfile/cli && ff-cli --version` works locally