### PR TITLE
chore: bump version to 1.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "ff-cli",
-  "version": "1.0.17",
+  "name": "@feralfile/cli",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ff-cli",
-      "version": "1.0.17",
+      "name": "@feralfile/cli",
+      "version": "1.0.18",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -21,7 +21,7 @@
         "viem": "^2.38.2"
       },
       "bin": {
-        "ff1": "dist/index.js"
+        "ff-cli": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^24.7.1",
@@ -3197,17 +3197,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feralfile/cli",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "CLI to fetch NFT information and build DP1 playlists using Grok API",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Cuts the first release of `@feralfile/cli` (continues version sequence from `ff1-cli@1.0.17`).

After merge, create a GitHub Release with tag `1.0.18` to trigger the npm publish workflow.