### PR TITLE
feat: add Claude as AI provider and default model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      GROK_API_KEY: dummy
+      ANTHROPIC_API_KEY: dummy
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      GROK_API_KEY: release-ci
+      ANTHROPIC_API_KEY: release-ci
     steps:
       - uses: actions/checkout@v4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ For behavior changes:
 Required verification commands:
 
 ```bash
-GROK_API_KEY=dummy npm run verify
+ANTHROPIC_API_KEY=dummy npm run verify
 ```
 
 This is the same non-mutating entrypoint used by `.github/workflows/ci.yml` after `npm ci` on Node.js 22. Use `npm run lint:fix` only as an optional mutating cleanup step, then review and verify the resulting edits before committing.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npx @feralfile/cli chat
 
 ## Quick Start
 
-**Set your LLM API key first (default Grok):** `export GROK_API_KEY='xai-your-api-key-here'`
+**Set your LLM API key first (default Claude):** `export ANTHROPIC_API_KEY='sk-ant-your-api-key-here'`
 
 ```bash
 ff-cli setup
@@ -46,7 +46,7 @@ ff-cli config validate
 
 ## Dev Quick Start
 
-**Set your LLM API key first (default Grok):** `export GROK_API_KEY='xai-your-api-key-here'`
+**Set your LLM API key first (default Claude):** `export ANTHROPIC_API_KEY='sk-ant-your-api-key-here'`
 
 ```bash
 npm ci
@@ -65,10 +65,10 @@ npm run dev -- play "https://example.com/video.mp4" --skip-verify
 
 ## Verification
 
-GitHub Actions runs `.github/workflows/ci.yml` for pull requests, pushes to `main`/`master`, and reusable `workflow_call` jobs. CI uses Node.js 22, installs dependencies with `npm ci`, sets `GROK_API_KEY=dummy`, and runs the repo-wide verification entrypoint:
+GitHub Actions runs `.github/workflows/ci.yml` for pull requests, pushes to `main`/`master`, and reusable `workflow_call` jobs. CI uses Node.js 22, installs dependencies with `npm ci`, sets `ANTHROPIC_API_KEY=dummy`, and runs the repo-wide verification entrypoint:
 
 ```bash
-GROK_API_KEY=dummy npm run verify
+ANTHROPIC_API_KEY=dummy npm run verify
 ```
 
 Run the same command locally before opening a PR. It checks formatting, lint, tests, TypeScript build, playlist validation smoke, and config validation smoke without mutating source files.

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,21 @@
 {
-  "defaultModel": "grok",
+  "defaultModel": "claude",
   "models": {
+    "claude": {
+      "apiKey": "YOUR_ANTHROPIC_API_KEY_FROM_CONSOLE_ANTHROPIC_COM",
+      "baseURL": "https://api.anthropic.com/v1/",
+      "model": "claude-sonnet-4-6",
+      "availableModels": [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001"
+      ],
+      "timeout": 30000,
+      "maxRetries": 3,
+      "temperature": 0.3,
+      "maxTokens": 4000,
+      "supportsFunctionCalling": true
+    },
     "grok": {
       "apiKey": "YOUR_GROK_API_KEY_FROM_X_AI_CONSOLE",
       "baseURL": "https://api.x.ai/v1",
@@ -16,7 +31,7 @@
       "maxTokens": 4000,
       "supportsFunctionCalling": true
     },
-    "chatgpt": {
+    "gpt": {
       "apiKey": "YOUR_OPENAI_API_KEY_FROM_PLATFORM_OPENAI_COM",
       "baseURL": "https://api.openai.com/v1",
       "model": "gpt-4.1",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -44,6 +44,7 @@ Each key under `models` defines a model configuration used by the AI orchestrato
 
 Environment variable helpers:
 
+- Anthropic (Claude): `ANTHROPIC_API_KEY`
 - Grok: `GROK_API_KEY`, `GROK_MODEL`, `GROK_API_BASE_URL`
 - OpenAI: `OPENAI_API_KEY`
 - Gemini: `GEMINI_API_KEY`
@@ -165,12 +166,12 @@ Minimal `config.json` example (selected fields):
 
 ```json
 {
-  "defaultModel": "grok",
+  "defaultModel": "claude",
   "models": {
-    "grok": {
-      "apiKey": "xai-your-api-key-here",
-      "baseURL": "https://api.x.ai/v1",
-      "model": "grok-beta",
+    "claude": {
+      "apiKey": "sk-ant-your-api-key-here",
+      "baseURL": "https://api.anthropic.com/v1/",
+      "model": "claude-sonnet-4-6",
       "supportsFunctionCalling": true
     }
   },

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -216,8 +216,8 @@ The current repo verification path is:
 npm run lint:fix
 npm test
 npm run build
-GROK_API_KEY=dummy node dist/index.js validate examples/sample-playlist.json
-GROK_API_KEY=dummy node dist/index.js config validate
+ANTHROPIC_API_KEY=dummy node dist/index.js validate examples/sample-playlist.json
+ANTHROPIC_API_KEY=dummy node dist/index.js config validate
 ```
 
 ## Open questions

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,14 @@ ff-cli config validate
 
 ```json
 {
-  "defaultModel": "grok",
+  "defaultModel": "claude",
   "models": {
+    "claude": {
+      "apiKey": "sk-ant-your-api-key-here",
+      "baseURL": "https://api.anthropic.com/v1/",
+      "model": "claude-sonnet-4-6",
+      "supportsFunctionCalling": true
+    },
     "grok": {
       "apiKey": "xai-your-api-key-here",
       "baseURL": "https://api.x.ai/v1",
@@ -182,7 +188,7 @@ How it works (at a glance):
 - If `deviceName` is present, the CLI will send the validated playlist to that FF1 device.
 - If `feedServer` is present (via "publish to my feed"), the CLI will publish the playlist to the selected feed server.
 
-Use `--model grok|gpt|gemini` to switch models, or set `defaultModel` in `config.json`.
+Use `--model claude|grok|gpt|gemini` to switch models, or set `defaultModel` in `config.json`.
 
 ### Natural language publishing
 

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,7 @@ const program = new Command();
 program
   .name('ff-cli')
   .description(
-    'CLI to fetch NFT information and build DP1 playlists using AI (Grok, ChatGPT, Gemini)'
+    'CLI to fetch NFT information and build DP1 playlists using AI (Claude, Grok, ChatGPT, Gemini)'
   )
   .version(packageVersion)
   .addHelpText(

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -13,7 +13,10 @@ export const chatCommand = new Command('chat')
   .description('Start an interactive chat to build playlists using natural language')
   .argument('[content]', 'Optional: Direct chat content (non-interactive mode)')
   .option('-o, --output <filename>', 'Output filename for the playlist', 'playlist.json')
-  .option('-m, --model <name>', 'AI model to use (grok, gpt, gemini) - defaults to config setting')
+  .option(
+    '-m, --model <name>',
+    'AI model to use (claude, grok, gpt, gemini) - defaults to config setting'
+  )
   .option('-d, --device <name>', 'Target FF1 device name (defaults to first configured device)')
   .option('-v, --verbose', 'Show detailed technical output of function calls', false)
   .action(

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import { findExistingDeviceEntry } from '../utilities/device-lookup';
 import { upsertDevice } from '../utilities/device-upsert';
+import { getConfig, listAvailableModels } from '../config';
 import { ensureConfigFile, isMissingConfigValue, readConfigFile } from './helpers/config-files';
 import { discoverAndSelectDevice } from './helpers/device-discovery';
 import { createPrompt, promptYesNo } from './helpers/prompt';
@@ -23,7 +24,13 @@ export const setupCommand = new Command('setup')
       }
 
       const config = await readConfigFile(configPath);
-      const modelNames = Object.keys(config.models || {});
+      const mergedDefaults = getConfig();
+      // Show every known provider in the menu (in-code defaults first, then any
+      // custom providers the user has added to the file) so adding a new provider
+      // to defaults shows up for existing users without rerunning createSampleConfig.
+      const modelNames = Array.from(
+        new Set([...listAvailableModels(), ...Object.keys(config.models || {})])
+      );
 
       if (modelNames.length === 0) {
         console.error(chalk.red('No models found in config.json'));
@@ -57,22 +64,34 @@ export const setupCommand = new Command('setup')
       }
 
       config.defaultModel = selectedModel;
-      const selectedModelConfig = config.models[selectedModel] || {
-        apiKey: '',
-        baseURL: '',
-        model: '',
-        timeout: 0,
-        maxRetries: 0,
-        temperature: 0,
-        maxTokens: 0,
-        supportsFunctionCalling: true,
-      };
+      if (!config.models) {
+        config.models = {};
+      }
+      // Seed missing entries from in-code defaults so baseURL/model are populated,
+      // but blank the apiKey so the user is prompted instead of silently inheriting
+      // an env-derived value.
+      const providerDefaults = mergedDefaults.models[selectedModel];
+      const selectedModelConfig =
+        config.models[selectedModel] ||
+        (providerDefaults
+          ? { ...providerDefaults, apiKey: '' }
+          : {
+              apiKey: '',
+              baseURL: '',
+              model: '',
+              timeout: 0,
+              maxRetries: 0,
+              temperature: 0,
+              maxTokens: 0,
+              supportsFunctionCalling: true,
+            });
 
       const hasApiKeyForModel = !isMissingConfigValue(selectedModelConfig.apiKey);
       const keyHelpUrls: Record<string, string> = {
         grok: 'https://console.x.ai/',
         gpt: 'https://platform.openai.com/api-keys',
         gemini: 'https://aistudio.google.com/app/apikey',
+        claude: 'https://console.anthropic.com/settings/keys',
       };
       if (!hasApiKeyForModel) {
         const helpUrl = keyHelpUrls[selectedModel];

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,8 +69,19 @@ function loadConfig(): Config {
 
   // Default configuration supporting Grok as default
   const defaultConfig: Config = {
-    defaultModel: process.env.DEFAULT_MODEL || 'grok',
+    defaultModel: process.env.DEFAULT_MODEL || 'claude',
     models: {
+      claude: {
+        apiKey: process.env.ANTHROPIC_API_KEY || '',
+        baseURL: 'https://api.anthropic.com/v1/',
+        model: 'claude-sonnet-4-6',
+        availableModels: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+        timeout: 30000,
+        maxRetries: 3,
+        temperature: 0.3,
+        maxTokens: 4000,
+        supportsFunctionCalling: true,
+      },
       grok: {
         apiKey: process.env.GROK_API_KEY || '',
         baseURL: process.env.GROK_API_BASE_URL || 'https://api.x.ai/v1',


### PR DESCRIPTION
## Summary

- Wires Anthropic Claude into the provider list via the existing OpenAI-compatible client (`baseURL` `https://api.anthropic.com/v1/`) — no SDK swap needed.
- Reorders the provider menu so `claude` leads, and makes Claude the new default model in both `src/config.ts` and `config.json.example`.
- Updates CI workflows (`ci.yml`, `release.yml`) and docs to use `ANTHROPIC_API_KEY=dummy` in place of `GROK_API_KEY=dummy` for the config-validation env.
- Fixes a pre-existing `chatgpt`/`gpt` key mismatch in `config.json.example` that was surfaced by the new provider-merge logic in `setup`.
- Updates `setup` to union in-code provider defaults with whatever's in the user's file, so adding a new provider shows up in the menu without regenerating `config.json`.

## Behavior change

The default LLM flips from grok → claude. Existing users with an explicit `defaultModel: "grok"` in their config are unaffected. New users created via `ff-cli setup` (or no config at all) will default to Claude and need `ANTHROPIC_API_KEY` set.

## Test plan

- [x] `ANTHROPIC_API_KEY=dummy npm run verify` — all 231 tests pass, lint + format clean, smoke `config validate` succeeds with new default
- [x] Manual `npm run dev -- setup` against a fresh `XDG_CONFIG_HOME` — menu shows `(claude, grok, gpt, gemini) [claude]`
- [x] `npm run dev -- chat --help` shows updated provider list
- [ ] Maintainer to verify CI passes on this PR before merge