### PR TITLE
ci(release): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,12 @@ jobs:
       - verify-version
     if: github.event_name == 'release' || github.ref_name == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # OIDC token used by `npm publish --provenance` to authenticate against
+      # the trusted-publisher configured for @feralfile/cli on npmjs.org.
+      id-token: write
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       ANTHROPIC_API_KEY: release-ci
     steps:
       - uses: actions/checkout@v4
@@ -109,6 +112,11 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # npm 11.5.1+ is required for OIDC trusted publishing; the npm bundled
+      # with Node 22 is 10.x.
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -124,15 +132,15 @@ jobs:
               echo "Workflow dispatch beta runs must use a version containing 'beta'."
               exit 1
             fi
-            npm publish --tag beta --access public
+            npm publish --tag beta --access public --provenance
           elif [ "${{ github.event.release.prerelease }}" = "true" ]; then
             if [[ "${{ github.event.release.tag_name }}" != *beta* ]]; then
               echo "Beta releases must use a tag containing 'beta'."
               exit 1
             fi
-            npm publish --tag beta --access public
+            npm publish --tag beta --access public --provenance
           else
-            npm publish --access public
+            npm publish --access public --provenance
           fi
 
       - name: Verify beta publish

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,7 +31,7 @@ Run the appropriate script on each target platform and upload each pair to the G
 
 ## npm Publish Requirements
 
-- Set `NPM_TOKEN` in GitHub Actions secrets with an npm automation token.
+- Publishes use **npm Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret is required or used. The trust is configured at https://www.npmjs.com/package/@feralfile/cli/access (publisher: GitHub Actions, org: `feral-file`, repo: `ff-cli`, workflow: `release.yml`).
 - Ensure `package.json` version matches the release tag (e.g. tag `1.0.2` → `"version": "1.0.2"`). The release job fails fast when they differ.
 - A **regular** (non-prerelease) GitHub Release publishes with the default dist-tag **`latest`**.
 - A GitHub Release marked **Set as a pre-release** publishes to the **`beta`** dist-tag, and its version must contain `beta` so the package version stays aligned with the beta channel.


### PR DESCRIPTION
## Summary

Switches the `publish-npm` job in `release.yml` from token-based auth (`NPM_TOKEN`) to **npm Trusted Publishing** via GitHub Actions OIDC. The trusted publisher is configured at https://www.npmjs.com/package/@feralfile/cli/access.

## Changes

- Drop `NODE_AUTH_TOKEN` and `NPM_TOKEN` env vars from the `publish-npm` job.
- Add `permissions: id-token: write, contents: read` to the job so OIDC tokens can be minted.
- Upgrade npm to latest (`npm install -g npm@latest`) in CI — OIDC trusted publishing requires npm ≥11.5.1, and Node 22's bundled npm is 10.x.
- Add `--provenance` to all three `npm publish` invocations so every release ships with a SLSA provenance attestation (free trust signal for consumers).
- Update `docs/RELEASING.md` to remove the `NPM_TOKEN` requirement and point at the npm trust config page.

## After merge

The `NPM_TOKEN` GitHub secret can (and should) be deleted:

\`\`\`
gh secret delete NPM_TOKEN -R feral-file/ff-cli
\`\`\`

Optional hardening: flip "Publishing access" at https://www.npmjs.com/package/@feralfile/cli/access from "Require 2FA or token-with-bypass" to "Require 2FA and disallow tokens" — that's only safe once we've confirmed an OIDC release publishes cleanly.

## Test plan

- [x] \`ANTHROPIC_API_KEY=dummy npm run verify\` passes locally
- [ ] CI on this PR is green
- [ ] After merge, cut a small follow-up release (e.g. v1.1.2) to confirm OIDC publishes end-to-end