### PR TITLE
ci(release): use Node 24 for npm publish (fixes OIDC upgrade crash)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,16 +107,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 24 ships with npm 11.x, which is required for OIDC trusted
+      # publishing. The package's engines floor (Node 22) still applies to
+      # consumers; this only affects how CI itself publishes.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      # npm 11.5.1+ is required for OIDC trusted publishing; the npm bundled
-      # with Node 22 is 10.x.
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What happened

v1.1.2 release ran with #61's workflow, which tried \`npm install -g npm@latest\` to get to npm 11.5+ (required for OIDC trusted publishing). That command failed mid-upgrade:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

Classic self-replacement issue — the running npm overwrites its own internals before finishing.

## Fix

Skip the in-place upgrade. Use Node 24 for the \`publish-npm\` job; it ships with npm 11.x natively. The package's \`engines: node >=22\` floor is unchanged — only the publish job itself uses Node 24.

## After merge

I'll bump to v1.1.3 and cut a release to confirm the OIDC publish actually works end-to-end. The v1.1.2 tag exists but never got to npm; v1.1.3 will be the real first OIDC publish.