### PR TITLE
chore: bump GitHub Actions to v5 and sweep stale ff1 references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
             script: powershell -ExecutionPolicy Bypass -File ./scripts/release/build-asset-windows.ps1
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
           FF_CLI_VERSION: ${{ github.event_name == 'pull_request' && '0.1' || inputs.version }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-${{ matrix.os }}
           path: release/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
       ANTHROPIC_API_KEY: dummy
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
           - javascript-typescript
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -34,7 +34,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,12 @@ jobs:
     if: github.event_name == 'release' || github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 
@@ -105,13 +105,13 @@ jobs:
     env:
       ANTHROPIC_API_KEY: release-ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Node 24 ships with npm 11.x, which is required for OIDC trusted
       # publishing. The package's engines floor (Node 22) still applies to
       # consumers; this only affects how CI itself publishes.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -175,10 +175,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true

--- a/index.ts
+++ b/index.ts
@@ -32,15 +32,15 @@ try {
 } catch {
   packageJsonPath = resolve(dirname(__filename), 'package.json');
 }
-const { version: packageVersion } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const { version: packageVersion, description: packageDescription } = JSON.parse(
+  readFileSync(packageJsonPath, 'utf8')
+);
 
 const program = new Command();
 
 program
   .name('ff-cli')
-  .description(
-    'CLI for building DP-1 playlists of digital art using AI (Claude, Grok, ChatGPT, Gemini)'
-  )
+  .description(packageDescription)
   .version(packageVersion)
   .addHelpText(
     'after',

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -31,9 +31,9 @@ export const buildCommand = new Command('build')
         if (!stdin.trim()) {
           console.error(chalk.red('No parameters provided'));
           console.log(chalk.yellow('\nUsage:'));
-          console.log('  ff1 build params.json');
-          console.log('  cat params.json | ff1 build');
-          console.log('  echo \'{"requirements":[...]}\' | ff1 build');
+          console.log('  ff-cli build params.json');
+          console.log('  cat params.json | ff-cli build');
+          console.log('  echo \'{"requirements":[...]}\' | ff-cli build');
           process.exit(1);
         }
 

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -42,13 +42,13 @@ export const chatCommand = new Command('chat')
           validation.errors.forEach((error) => {
             console.error(chalk.red(`  • ${error}`));
           });
-          console.log(chalk.yellow('\nRun: ff1 setup\n'));
+          console.log(chalk.yellow('\nRun: ff-cli setup\n'));
           process.exit(1);
         }
 
         // Non-interactive mode: content was passed as a positional argument.
         if (content) {
-          console.log(chalk.blue('\nFF1 Chat (non-interactive)\n'));
+          console.log(chalk.blue('\nff-cli chat (non-interactive)\n'));
           console.log(chalk.dim(`Model: ${modelName}\n`));
           console.log(chalk.yellow('Request:'), content);
           console.log();
@@ -80,7 +80,7 @@ export const chatCommand = new Command('chat')
         }
 
         // Interactive mode.
-        console.log(chalk.blue('\nFF1 Chat\n'));
+        console.log(chalk.blue('\nff-cli chat\n'));
         console.log(chalk.dim('Describe the playlist you want. Ctrl+C to exit.'));
         console.log(chalk.dim(`Model: ${modelName}\n`));
         console.log(chalk.dim('Examples:'));

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -10,7 +10,7 @@ import {
 
 // `config` is a single command with an action argument rather than a
 // commander subcommand group. Kept this way to preserve the existing
-// CLI surface (`ff1 config init|show|validate`) used in scripts.
+// CLI surface (`ff-cli config init|show|validate`) used in scripts.
 
 export const configCommand = new Command('config')
   .description('Manage configuration')
@@ -22,7 +22,7 @@ export const configCommand = new Command('config')
         const { userPath } = getConfigPaths();
         const configPath = await createSampleConfig(userPath);
         console.log(chalk.green(`Created ${configPath}`));
-        console.log(chalk.yellow('\nNext: ff1 setup\n'));
+        console.log(chalk.yellow('\nNext: ff-cli setup\n'));
       } else if (action === 'show') {
         const config = getConfig();
         console.log(chalk.blue('\nCurrent configuration\n'));

--- a/src/commands/device.ts
+++ b/src/commands/device.ts
@@ -19,7 +19,7 @@ deviceCommand
       const configPath = await resolveExistingConfigPath();
       if (!configPath) {
         console.log(chalk.red('config.json not found'));
-        console.log(chalk.dim('Run: ff1 setup'));
+        console.log(chalk.dim('Run: ff-cli setup'));
         process.exit(1);
       }
 
@@ -28,7 +28,7 @@ deviceCommand
 
       if (devices.length === 0) {
         console.log(chalk.yellow('\nNo devices configured'));
-        console.log(chalk.dim('Run: ff1 device add'));
+        console.log(chalk.dim('Run: ff-cli device add'));
         console.log();
         return;
       }
@@ -81,7 +81,7 @@ deviceCommand
       const configPath = await resolveExistingConfigPath();
       if (!configPath) {
         console.log(chalk.red('config.json not found'));
-        console.log(chalk.dim('Run: ff1 setup'));
+        console.log(chalk.dim('Run: ff-cli setup'));
         process.exit(1);
       }
 
@@ -178,7 +178,7 @@ deviceCommand
               `\nError: device name "${deviceName}" is already used by another device (${nameConflict.host}).`
             )
           );
-          console.error(chalk.dim('Use a different name or run "ff1 device remove" first.'));
+          console.error(chalk.dim('Use a different name or run "ff-cli device remove" first.'));
           closePrompt();
           process.exit(1);
         }
@@ -283,7 +283,7 @@ deviceCommand
       const configPath = await resolveExistingConfigPath();
       if (!configPath) {
         console.log(chalk.red('config.json not found'));
-        console.log(chalk.dim('Run: ff1 setup'));
+        console.log(chalk.dim('Run: ff-cli setup'));
         process.exit(1);
       }
 
@@ -292,7 +292,7 @@ deviceCommand
 
       if (existingDevices.length === 0) {
         console.log(chalk.yellow('\nNo devices configured'));
-        console.log(chalk.dim('Run: ff1 device add\n'));
+        console.log(chalk.dim('Run: ff-cli device add\n'));
         process.exit(1);
       }
 

--- a/src/commands/helpers/device-discovery.ts
+++ b/src/commands/helpers/device-discovery.ts
@@ -17,7 +17,7 @@ export interface DeviceDiscoverySelection {
  * Run mDNS discovery and prompt the user to pick a device, fall back to
  * manual entry, or skip when an existing device is already configured.
  *
- * Shared between `ff1 setup` and `ff1 device add` so both flows present
+ * Shared between `ff-cli setup` and `ff-cli device add` so both flows present
  * the same selection UX and matching rules.
  */
 export async function discoverAndSelectDevice(

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -37,7 +37,7 @@ export const setupCommand = new Command('setup')
         process.exit(1);
       }
 
-      console.log(chalk.blue('\nFF1 Setup\n'));
+      console.log(chalk.blue('\nff-cli setup\n'));
 
       prompt = createPrompt();
       const ask = prompt.ask;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -16,7 +16,7 @@ export const statusCommand = new Command('status')
       const configPath = await resolveExistingConfigPath();
       if (!configPath) {
         console.log(chalk.red('config.json not found'));
-        console.log(chalk.dim('Run: ff1 setup'));
+        console.log(chalk.dim('Run: ff-cli setup'));
         process.exit(1);
       }
 
@@ -115,7 +115,7 @@ export const statusCommand = new Command('status')
           !status.ok && (!status.optional || Boolean((status as { invalid?: boolean }).invalid))
       );
       if (hasRequired) {
-        console.log(chalk.dim('\nRun: ff1 setup'));
+        console.log(chalk.dim('\nRun: ff-cli setup'));
         process.exit(1);
       }
     } catch (error) {

--- a/src/intent-parser/index.ts
+++ b/src/intent-parser/index.ts
@@ -1239,7 +1239,7 @@ export async function processIntentParserRequest(
 
         // Validate and confirm the playlist.
         // args.deviceName may be null/undefined/"null" when the model omits it;
-        // fall back to the CLI --device flag so `ff1 chat --device kitchen` works.
+        // fall back to the CLI --device flag so `ff-cli chat --device kitchen` works.
         const resolvedDeviceName =
           args.deviceName && args.deviceName !== 'null' ? args.deviceName : defaultDeviceName;
         const confirmation = await confirmPlaylistForSending(args.filePath, resolvedDeviceName);

--- a/src/utilities/ff1-device.ts
+++ b/src/utilities/ff1-device.ts
@@ -210,7 +210,7 @@ export async function sendPlaylistToDevice({
         error: `Could not reach device "${deviceLabel}" at ${device.host}`,
         details:
           'Check that the device is powered on and reachable on your network. ' +
-          'If the device IP changed (e.g. after a factory reset), run: ff1 setup',
+          'If the device IP changed (e.g. after a factory reset), run: ff-cli setup',
       };
     }
 
@@ -250,7 +250,7 @@ export async function sendPlaylistToDevice({
         error: `Could not reach device "${deviceLabel}" at ${device.host}`,
         details:
           'Check that the device is powered on and reachable on your network. ' +
-          'If the device IP changed (e.g. after a factory reset), run: ff1 setup',
+          'If the device IP changed (e.g. after a factory reset), run: ff-cli setup',
       };
     }
 


### PR DESCRIPTION
Three small cleanups bundled together.

## 1. GitHub Actions v4 → v5

Every recent workflow run printed:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

Bumping all of `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, and `actions/dependency-review-action` from v4 to v5. v5 is Node 24 native, so the warning goes away and we're ready for the cut-off.

## 2. CLI description from `package.json`

Previously the description string lived in both `package.json` and `index.ts`. Updating it meant remembering both. `index.ts` already reads `version` from `package.json` — same trick for `description`. Single source of truth.

## 3. Sweep stale `ff1 <subcommand>` strings

After the `ff1-cli` → `ff-cli` rename (PR #56), 16 user-facing strings across `src/` still pointed users at `ff1 setup`, `ff1 chat`, `ff1 device add`, etc. — commands that no longer exist. All updated. Hardware-context "FF1" references (`FF1Device` type, `_ff1._tcp` mDNS service, FF1 OS) are preserved as intended.

## Test plan

- [x] \`ANTHROPIC_API_KEY=dummy npm run verify\` passes
- [ ] CI is green on this PR (will confirm v5 actions actually work end-to-end)