### PR TITLE
fix(indexer): accept `succeeded` as terminal job status

### DIFF
--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -922,9 +922,14 @@ async function pollForJobCompletion(jobId, options = {}) {
 
       const normalized = typeof status === 'string' ? status.toLowerCase() : '';
 
-      if (normalized === 'completed') {
+      // Indexer terminal-success states: both `completed` (older) and
+      // `succeeded` (current pgmq convention) appear in the wild. Accepting
+      // both prevents the CLI from polling-to-timeout on freshly-triggered
+      // tokens, which was masking as "No tokens could be indexed" on the
+      // first encounter while the underlying job had already finished.
+      if (normalized === 'completed' || normalized === 'succeeded') {
         const elapsedMs = Date.now() - startTime;
-        logger.info(`[NFT Indexer] ✓ Job completed after ${pollCount} polls (${elapsedMs}ms)`);
+        logger.info(`[NFT Indexer] ✓ Job ${normalized} after ${pollCount} polls (${elapsedMs}ms)`);
         return {
           success: true,
           completed: true,


### PR DESCRIPTION
## Summary
- The polling loop only treated `completed` as terminal success; indexer emits `succeeded`. Result: CLI polled to timeout on freshly-triggered tokens.
- Adds `succeeded` alongside `completed`. No behavior change for jobs that already report `completed`.

## Reproduction
Live probe (2026-05-18) on BAYC #1:
```
trigger → job_id 337449
poll: status=running
poll: status=succeeded   ← CLI never matched this
```
Symptom in `ff-cli find`: "No tokens could be indexed" on the first encounter with any unseen token; works on the second run because the token is now cached.

## Test plan
- [x] `npm run check` (231/231 pass)
- [ ] Manual: `ff-cli find` against an unseen OpenSea/AB token builds a playlist on first try