### PR TITLE
feat(build): resolve Feral File artwork ids

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -70,11 +70,34 @@ npm run dev -- build examples/params-example.json -o playlist.json
 cat examples/params-example.json | npm run dev -- build -o playlist.json
 ```
 
+Build from a Feral File public artwork id or artwork URL:
+
+```bash
+cat > /tmp/ff-artwork.json <<'JSON'
+{
+  "requirements": [
+    {
+      "type": "feral_file_artwork",
+      "artworkId": "https://feralfile.com/exhibitions/artwork/f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf"
+    }
+  ],
+  "playlistSettings": {
+    "title": "Feral File Artwork"
+  }
+}
+JSON
+
+npm run dev -- build /tmp/ff-artwork.json -o playlist.json
+```
+
 ## AI‑Orchestrated Deterministic Flow (prompts)
 
 ```bash
 # Show tool‑call progress and validation
 npm run dev -- chat "Build a playlist of my works from reas.eth plus 3 from Unsupervised" -v -o playlist.json
+
+# Build from a Feral File artwork URL
+npm run dev -- chat "Build a playlist from https://feralfile.com/exhibitions/artwork/f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf" -v -o playlist.json
 
 # Switch model if desired
 npm run dev -- chat "Build playlist from Ethereum address 0xaeE022552B539dB18297D7481b6D547C622488B3 and 2 from Unsupervised" --model gpt -v

--- a/docs/FUNCTION_CALLING.md
+++ b/docs/FUNCTION_CALLING.md
@@ -24,8 +24,9 @@ Key files:
 Defined in `src/ai-orchestrator/index.js` as tool schemas for OpenAI‑compatible clients.
 
 - `query_requirement(requirement, duration)`
-  - Types: `build_playlist`, `fetch_feed`, `query_address`
+  - Types: `build_playlist`, `feral_file_artwork`, `fetch_feed`, `query_address`
   - For `build_playlist`: requires `blockchain`, `contractAddress`, `tokenIds`, optional `quantity`
+  - For `feral_file_artwork`: requires `artworkId`, either a Feral File public artwork id or `/exhibitions/artwork/{id}` URL
   - For `query_address`: requires `ownerAddress`, optional `quantity` (random selection)
   - For `fetch_feed`: requires `playlistName`, `quantity`
 
@@ -65,6 +66,7 @@ Two options are available:
 {
   "requirements": [
     { "type": "fetch_feed", "playlistName": "Social Codes", "quantity": 3 },
+    { "type": "feral_file_artwork", "artworkId": "https://feralfile.com/exhibitions/artwork/..." },
     {
       "type": "build_playlist",
       "blockchain": "ethereum",

--- a/src/ai-orchestrator/index.js
+++ b/src/ai-orchestrator/index.js
@@ -133,7 +133,7 @@ const functionSchemas = [
     function: {
       name: 'query_requirement',
       description:
-        'Query data for a requirement. Supports build_playlist (blockchain NFTs), query_address (all NFTs from address), and fetch_feed (feed playlists) types.',
+        'Query data for a requirement. Supports build_playlist (blockchain NFTs), feral_file_artwork (Feral File artwork IDs/URLs), query_address (all NFTs from address), and fetch_feed (feed playlists) types.',
       parameters: {
         type: 'object',
         properties: {
@@ -144,7 +144,7 @@ const functionSchemas = [
             properties: {
               type: {
                 type: 'string',
-                enum: ['build_playlist', 'fetch_feed', 'query_address'],
+                enum: ['build_playlist', 'feral_file_artwork', 'fetch_feed', 'query_address'],
                 description: 'Type of requirement',
               },
               blockchain: {
@@ -163,6 +163,11 @@ const functionSchemas = [
                 items: {
                   type: 'string',
                 },
+              },
+              artworkId: {
+                type: 'string',
+                description:
+                  'Feral File public artwork id or /exhibitions/artwork/{id} URL (REQUIRED for feral_file_artwork)',
               },
               ownerAddress: {
                 type: 'string',
@@ -514,6 +519,8 @@ function buildOrchestratorSystemPrompt(params) {
     .map((req, i) => {
       if (req.type === 'fetch_feed') {
         return `${i + 1}. Fetch ${req.quantity || 5} items from playlist "${req.playlistName}"`;
+      } else if (req.type === 'feral_file_artwork') {
+        return `${i + 1}. Resolve Feral File artwork ${req.artworkId}`;
       } else if (req.type === 'query_address') {
         const quantityText =
           req.quantity === 'all' ? 'all ' : req.quantity ? req.quantity + ' random ' : 'all ';
@@ -572,6 +579,8 @@ KEY RULES
 DECISION LOOP
 1) For each requirement in order:
    - build_playlist: call query_requirement(requirement, duration=${playlistSettings.durationPerItem || 10}).
+     Returns array with minimal item data including id field. Collect the id values.
+   - feral_file_artwork: call query_requirement(requirement, duration=${playlistSettings.durationPerItem || 10}).
      Returns array with minimal item data including id field. Collect the id values.
    - query_address:
      • if ownerAddress endsWith .eth/.tez → resolve_domains([domain]); if resolved → use returned address; if not → mark failed and continue.
@@ -675,6 +684,8 @@ async function buildPlaylistWithAI(params, options = {}) {
       .map((req, i) => {
         if (req.type === 'fetch_feed') {
           return `${i + 1}. Fetch ${req.quantity || 5} items from playlist "${req.playlistName}"`;
+        } else if (req.type === 'feral_file_artwork') {
+          return `${i + 1}. Resolve Feral File artwork:\n   - artworkId: "${req.artworkId}"`;
         } else if (req.type === 'query_address') {
           const quantityDesc =
             req.quantity === 'all'

--- a/src/intent-parser/index.ts
+++ b/src/intent-parser/index.ts
@@ -111,6 +111,7 @@ OUTPUT CONTRACT
 
 REQUIREMENT TYPES (BUILD)
 - build_playlist: { type, blockchain: "ethereum"|"tezos", contractAddress, tokenIds?: string[], quantity?: number, source?: string }
+- feral_file_artwork: { type, artworkId } for Feral File artwork URLs or public artwork ids.
   • USE THIS when user mentions "contract" with a quantity: "N items from [blockchain] contract [address]"
   • tokenIds is OPTIONAL - omit it when user wants random tokens from a contract
   • Examples:
@@ -148,6 +149,10 @@ EXAMPLES (build_playlist - contract addresses)
 - "create a playlist of 100 items from ethereum contract 0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270" → \`build_playlist\` { blockchain: "ethereum", contractAddress: "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270", quantity: 100 }
 - "100 random tokens from tezos contract KT1abc" → \`build_playlist\` { blockchain: "tezos", contractAddress: "KT1abc", quantity: 100 }
 - "get 50 from contract 0xDEF" → \`build_playlist\` { blockchain: "ethereum", contractAddress: "0xDEF", quantity: 50 }
+
+EXAMPLES (feral_file_artwork - public artwork URLs)
+- "build a playlist from https://feralfile.com/exhibitions/artwork/abc123" → \`feral_file_artwork\` { artworkId: "abc123" }
+- "play Feral File artwork f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf" → \`feral_file_artwork\` { artworkId: "f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf" }
 
 EXAMPLES (fetch_feed)
 - "Pick 3 artworks from Social Codes and 2 from a2p. Mix them up." → \`fetch_feed\` { playlistName: "Social Codes", quantity: 3 } + \`fetch_feed\` { playlistName: "a2p", quantity: 2 }, and set \`playlistSettings.preserveOrder\` = false
@@ -266,22 +271,22 @@ const intentParserFunctionSchemas: OpenAI.Chat.ChatCompletionTool[] = [
     function: {
       name: 'parse_requirements',
       description:
-        'Parse validated and complete requirements. Only call this when you have all required information for each requirement: blockchain, contract address, token IDs, and source.',
+        'Parse validated and complete requirements. Only call this when you have all required information for each requirement, such as blockchain/contract/token IDs, Feral File artwork id, feed playlist name, or owner address.',
       parameters: {
         type: 'object',
         properties: {
           requirements: {
             type: 'array',
             description:
-              'Array of parsed requirements. Each can be either build_playlist (specific NFTs), fetch_feed (feed playlist), or query_address (all NFTs from address)',
+              'Array of parsed requirements. Each can be build_playlist (specific NFTs), feral_file_artwork (Feral File public artwork id or URL), fetch_feed (feed playlist), or query_address (all NFTs from address)',
             items: {
               type: 'object',
               properties: {
                 type: {
                   type: 'string',
-                  enum: ['build_playlist', 'fetch_feed', 'query_address'],
+                  enum: ['build_playlist', 'feral_file_artwork', 'fetch_feed', 'query_address'],
                   description:
-                    'Type of requirement: build_playlist (specific NFTs), fetch_feed (feed playlist), or query_address (all NFTs from address)',
+                    'Type of requirement: build_playlist (specific NFTs), feral_file_artwork (Feral File artwork), fetch_feed (feed playlist), or query_address (all NFTs from address)',
                 },
                 blockchain: {
                   type: 'string',
@@ -299,6 +304,11 @@ const intentParserFunctionSchemas: OpenAI.Chat.ChatCompletionTool[] = [
                   items: {
                     type: 'string',
                   },
+                },
+                artworkId: {
+                  type: 'string',
+                  description:
+                    'Feral File public artwork id or artwork URL - only for feral_file_artwork type',
                 },
                 ownerAddress: {
                   type: 'string',

--- a/src/intent-parser/index.ts
+++ b/src/intent-parser/index.ts
@@ -111,13 +111,15 @@ OUTPUT CONTRACT
 
 REQUIREMENT TYPES (BUILD)
 - build_playlist: { type, blockchain: "ethereum"|"tezos", contractAddress, tokenIds?: string[], quantity?: number, source?: string }
-- feral_file_artwork: { type, artworkId } for Feral File artwork URLs or public artwork ids.
   • USE THIS when user mentions "contract" with a quantity: "N items from [blockchain] contract [address]"
   • tokenIds is OPTIONAL - omit it when user wants random tokens from a contract
   • Examples:
     - "tokens 1, 2, 3 from contract 0x123" → build_playlist with tokenIds: ["1", "2", "3"]
     - "100 items from ethereum contract 0xABC" → build_playlist with quantity: 100, NO tokenIds
     - "50 random tokens from tezos contract KT1..." → build_playlist with quantity: 50, NO tokenIds
+- feral_file_artwork: { type, artworkId } for Feral File artwork URLs or public artwork ids.
+  • USE THIS only for feralfile.com/exhibitions/artwork URLs or explicit Feral File public artwork ids
+  • Do not use this for ordinary blockchain contract prompts
 - query_address: { type, ownerAddress: 0x…|tz…|domain.eth|domain.tez, quantity?: number | "all" }
   • USE THIS for owner/wallet addresses WITHOUT the word "contract"
   • Patterns: "N items from [address]", "NFTs from [address]", "tokens owned by [address]"

--- a/src/intent-parser/utils.ts
+++ b/src/intent-parser/utils.ts
@@ -53,6 +53,10 @@ export function applyConstraints(params: RequirementParams, config: Config): Req
       if (!r.playlistName) {
         throw new Error(`Requirement ${index + 1}: playlistName is required for fetch_feed`);
       }
+    } else if (r.type === 'feral_file_artwork') {
+      if (!r.artworkId) {
+        throw new Error(`Requirement ${index + 1}: artworkId is required for feral_file_artwork`);
+      }
     } else {
       throw new Error(`Requirement ${index + 1}: invalid type "${r.type}"`);
     }
@@ -81,9 +85,9 @@ export function applyConstraints(params: RequirementParams, config: Config): Req
 
   // Note: No cap needed - registry system handles large playlists efficiently
   // Full items are stored in memory, only IDs are sent to AI model
-  const hasAllQuantity = params.requirements.some((r) => r.quantity === 'all');
+  const hasAllQuantity = params.requirements.some((r) => 'quantity' in r && r.quantity === 'all');
   const totalRequested = params.requirements.reduce((sum, r) => {
-    if (typeof r.quantity === 'number') {
+    if ('quantity' in r && typeof r.quantity === 'number') {
       return sum + r.quantity;
     }
     return sum;

--- a/src/main.ts
+++ b/src/main.ts
@@ -180,6 +180,13 @@ export function validateRequirements(requirements: Requirement[]): Requirement[]
       };
     }
 
+    if (req.type === 'feral_file_artwork') {
+      if (!req.artworkId) {
+        throw new Error(`Requirement ${index + 1}: artworkId is required for feral_file_artwork`);
+      }
+      return req;
+    }
+
     // Query address requirement
     if (req.type === 'query_address') {
       // Query all NFTs from an owner address

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,16 @@ export interface FetchFeedRequirement {
   quantity?: number | string;
 }
 
-export type Requirement = BuildPlaylistRequirement | QueryAddressRequirement | FetchFeedRequirement;
+export interface FeralFileArtworkRequirement {
+  type: 'feral_file_artwork';
+  artworkId: string;
+}
+
+export type Requirement =
+  | BuildPlaylistRequirement
+  | QueryAddressRequirement
+  | FetchFeedRequirement
+  | FeralFileArtworkRequirement;
 
 export interface BuildPlaylistParams {
   requirements: Requirement[];

--- a/src/utilities/feral-file-artwork.ts
+++ b/src/utilities/feral-file-artwork.ts
@@ -1,0 +1,117 @@
+/**
+ * Feral File public artwork API helpers.
+ *
+ * The exhibition API is the source of truth for public artwork IDs, including
+ * swapped artwork IDs where the public URL id differs from the on-chain token
+ * id. The CLI should consume the identity fields returned by the artwork
+ * endpoint instead of reconstructing contract identity from exhibition internals.
+ */
+
+export interface FeralFileArtworkTokenCoords {
+  chain: 'ethereum' | 'tezos';
+  contractAddress: string;
+  tokenId: string;
+}
+
+interface FeralFileArtworkResponse {
+  result?: {
+    id?: string;
+    chain?: unknown;
+    contractAddress?: unknown;
+    tokenID?: unknown;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
+/**
+ * resolveFeralFileArtwork resolves a public Feral File artwork id into indexer
+ * token coordinates using the self-describing artwork API response.
+ *
+ * @param artworkId - Public artwork id from Feral File.
+ * @param fetchImpl - Fetch implementation, injected by tests.
+ * @returns Token coordinates suitable for ff-indexer-v2 lookup.
+ */
+export async function resolveFeralFileArtwork(
+  artworkId: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<FeralFileArtworkTokenCoords> {
+  const normalizedArtworkId = artworkId.trim();
+  if (!normalizedArtworkId) {
+    throw new Error('Feral File artwork id is required');
+  }
+
+  const url = `https://feralfile.com/api/artworks/${encodeURIComponent(normalizedArtworkId)}`;
+  const response = await fetchImpl(url);
+  const body = (await response.json()) as FeralFileArtworkResponse;
+
+  if (!response.ok) {
+    throw new Error(body.error?.message || `Feral File artwork lookup failed (${response.status})`);
+  }
+
+  const artwork = body.result;
+  if (!artwork) {
+    throw new Error('Feral File artwork lookup returned no result');
+  }
+
+  const chain = normalizeFeralFileChain(artwork.chain);
+  const contractAddress = stringField(artwork.contractAddress, 'contractAddress');
+  const tokenId = stringField(artwork.tokenID, 'tokenID');
+
+  return { chain, contractAddress, tokenId };
+}
+
+/**
+ * parseFeralFileArtworkId extracts the public artwork id from supported Feral
+ * File artwork URLs. Non-URL strings are treated as raw artwork ids so
+ * structured build inputs can pass the id directly.
+ *
+ * @param input - Feral File artwork URL or raw public artwork id.
+ * @returns Public artwork id.
+ */
+export function parseFeralFileArtworkId(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Feral File artwork id is required');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+
+  const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+  if (host !== 'feralfile.com') {
+    throw new Error(`Unsupported Feral File artwork URL host: ${parsed.hostname}`);
+  }
+
+  const match = parsed.pathname.match(/^\/exhibitions\/artwork\/([^/]+)\/?$/);
+  if (!match) {
+    throw new Error('Unsupported Feral File artwork URL path');
+  }
+
+  return decodeURIComponent(match[1]);
+}
+
+function normalizeFeralFileChain(value: unknown): 'ethereum' | 'tezos' {
+  if (typeof value !== 'string') {
+    throw new Error('Feral File artwork is missing chain');
+  }
+
+  const normalized = value.toLowerCase();
+  if (normalized === 'ethereum' || normalized === 'tezos') {
+    return normalized;
+  }
+
+  throw new Error(`Unsupported Feral File artwork chain: ${value}`);
+}
+
+function stringField(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Feral File artwork is missing ${fieldName}`);
+  }
+  return value;
+}

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -275,8 +275,16 @@ async function queryTokensByAddress(ownerAddress, quantity, duration = 10, optio
  * @returns {Promise<Array>} Array of DP1 playlist items
  */
 async function queryRequirement(requirement, duration = 10) {
-  const { type, blockchain, contractAddress, tokenIds, ownerAddress, playlistName, quantity } =
-    requirement;
+  const {
+    type,
+    blockchain,
+    contractAddress,
+    tokenIds,
+    ownerAddress,
+    playlistName,
+    quantity,
+    artworkId,
+  } = requirement;
 
   // Handle query_address type
   if (type === 'query_address') {
@@ -339,6 +347,19 @@ async function queryRequirement(requirement, duration = 10) {
       );
       return [];
     }
+  }
+
+  if (type === 'feral_file_artwork') {
+    console.log(chalk.cyan(`Resolving Feral File artwork ${artworkId}...`));
+    const { parseFeralFileArtworkId, resolveFeralFileArtwork } = require('./feral-file-artwork');
+    const coords = await resolveFeralFileArtwork(parseFeralFileArtworkId(artworkId));
+    const items = await nftIndexer.getNFTTokenInfoBatch([coords], duration);
+    if (items.length > 0) {
+      console.log(chalk.green(`✓ Got ${items.length} item(s)`));
+    } else {
+      console.log(chalk.yellow('   No items found for Feral File artwork'));
+    }
+    return items;
   }
 
   // Handle build_playlist type (original NFT querying logic)

--- a/tests/feral-file-artwork.test.ts
+++ b/tests/feral-file-artwork.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  parseFeralFileArtworkId,
+  resolveFeralFileArtwork,
+} from '../src/utilities/feral-file-artwork';
+
+/**
+ * jsonResponse creates the minimal fetch Response surface used by the Feral
+ * File artwork resolver tests.
+ *
+ * @param body - JSON body returned by response.json().
+ * @param ok - Whether the HTTP response is successful.
+ * @param status - HTTP status code.
+ * @returns Minimal Response object.
+ */
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('parseFeralFileArtworkId', () => {
+  test('extracts public artwork id from Feral File artwork URL', () => {
+    assert.equal(
+      parseFeralFileArtworkId(
+        'https://feralfile.com/exhibitions/artwork/f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf'
+      ),
+      'f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf'
+    );
+  });
+
+  test('passes raw public artwork ids through', () => {
+    assert.equal(parseFeralFileArtworkId('abc123'), 'abc123');
+  });
+});
+
+describe('resolveFeralFileArtwork', () => {
+  test('uses artwork identity fields from one public API call', async () => {
+    const calls: string[] = [];
+    const coords = await resolveFeralFileArtwork('native-token-id', async (input) => {
+      calls.push(String(input));
+      return jsonResponse({
+        result: {
+          id: 'native-token-id',
+          chain: 'ethereum',
+          contractAddress: '0xBE0A4E26a156B2a60cF515E86b3Df9756DEE1952',
+          tokenID: 'native-token-id',
+        },
+      });
+    });
+
+    assert.deepEqual(coords, {
+      chain: 'ethereum',
+      contractAddress: '0xBE0A4E26a156B2a60cF515E86b3Df9756DEE1952',
+      tokenId: 'native-token-id',
+    });
+    assert.deepEqual(calls, ['https://feralfile.com/api/artworks/native-token-id']);
+  });
+
+  test('uses response tokenID for swapped public artwork ids', async () => {
+    const coords = await resolveFeralFileArtwork('public-swap-id', async () =>
+      jsonResponse({
+        result: {
+          id: 'public-swap-id',
+          chain: 'ethereum',
+          contractAddress: '0xDB5f1aDCFFA1869B9711cBFBe3Bf46cc5d5319E5',
+          tokenID: '92419109143972345096969611651362597777388673613154609693448331487805624917924',
+        },
+      })
+    );
+
+    assert.equal(
+      coords.tokenId,
+      '92419109143972345096969611651362597777388673613154609693448331487805624917924'
+    );
+  });
+
+  test('rejects missing token identity fields', async () => {
+    await assert.rejects(
+      resolveFeralFileArtwork('missing-token', async () =>
+        jsonResponse({
+          result: {
+            id: 'missing-token',
+            chain: 'ethereum',
+            contractAddress: '0xDB5f1aDCFFA1869B9711cBFBe3Bf46cc5d5319E5',
+          },
+        })
+      ),
+      /tokenID/
+    );
+  });
+
+  test('surfaces API 404 messages', async () => {
+    await assert.rejects(
+      resolveFeralFileArtwork('not-real', async () =>
+        jsonResponse({ error: { message: 'artwork not found' } }, false, 404)
+      ),
+      /artwork not found/
+    );
+  });
+});

--- a/tests/intent-parser-prompt.test.ts
+++ b/tests/intent-parser-prompt.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { buildIntentParserSystemPrompt } from '../src/intent-parser';
+
+describe('intent parser requirement guidance', () => {
+  test('keeps contract guidance under build_playlist, not feral_file_artwork', () => {
+    const prompt = buildIntentParserSystemPrompt();
+    const buildSection = sectionBetween(prompt, '- build_playlist:', '- feral_file_artwork:');
+    const feralFileSection = sectionBetween(prompt, '- feral_file_artwork:', '- query_address:');
+
+    assert.match(buildSection, /USE THIS when user mentions "contract" with a quantity/);
+    assert.match(buildSection, /"100 items from ethereum contract 0xABC" → build_playlist/);
+    assert.match(feralFileSection, /feralfile\.com\/exhibitions\/artwork/);
+    assert.match(feralFileSection, /Do not use this for ordinary blockchain contract prompts/);
+    assert.doesNotMatch(feralFileSection, /N items from \[blockchain\] contract/);
+    assert.doesNotMatch(feralFileSection, /"100 items from ethereum contract 0xABC"/);
+  });
+});
+
+/**
+ * sectionBetween extracts a prompt section bounded by stable headings.
+ *
+ * @param text - Prompt text to inspect.
+ * @param start - Inclusive section start marker.
+ * @param end - Exclusive section end marker.
+ * @returns Extracted section text.
+ */
+function sectionBetween(text: string, start: string, end: string): string {
+  const startIndex = text.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing start marker: ${start}`);
+  const endIndex = text.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `missing end marker: ${end}`);
+  return text.slice(startIndex, endIndex);
+}

--- a/tests/query-requirement-fallback.test.ts
+++ b/tests/query-requirement-fallback.test.ts
@@ -22,8 +22,10 @@ let contractCalls: Array<{ address: string; limit: number }> = [];
 
 const originalQueryTokensByOwner = nftIndexer.queryTokensByOwner;
 const originalQueryTokensByContract = nftIndexer.queryTokensByContract;
+const originalGetNFTTokenInfoBatch = nftIndexer.getNFTTokenInfoBatch;
 const originalMapIndexerDataToStandardFormat = nftIndexer.mapIndexerDataToStandardFormat;
 const originalConvertToDP1Item = nftIndexer.convertToDP1Item;
+const originalFetch = globalThis.fetch;
 
 /**
  * Build a deterministic DP1 item from minimal token input.
@@ -75,13 +77,24 @@ beforeEach(() => {
     success: true,
     item: toItem(mapped.token),
   });
+
+  nftIndexer.getNFTTokenInfoBatch = async (
+    tokens: Array<{ contractAddress: string; tokenId: string }>,
+    duration: number
+  ) =>
+    tokens.map((token) => ({
+      ...toItem({ contract_address: token.contractAddress, token_id: token.tokenId }),
+      duration,
+    }));
 });
 
 afterEach(() => {
   nftIndexer.queryTokensByOwner = originalQueryTokensByOwner;
   nftIndexer.queryTokensByContract = originalQueryTokensByContract;
+  nftIndexer.getNFTTokenInfoBatch = originalGetNFTTokenInfoBatch;
   nftIndexer.mapIndexerDataToStandardFormat = originalMapIndexerDataToStandardFormat;
   nftIndexer.convertToDP1Item = originalConvertToDP1Item;
+  globalThis.fetch = originalFetch;
 });
 
 describe('queryRequirement owner-to-contract fallback', () => {
@@ -118,5 +131,42 @@ describe('queryRequirement owner-to-contract fallback', () => {
     assert.equal(ownerCalls.length, 1);
     assert.equal(contractCalls.length, 0);
     assert.deepEqual(items, []);
+  });
+});
+
+describe('queryRequirement Feral File artwork', () => {
+  test('resolves artwork identity and fetches the returned token id', async () => {
+    const calls: string[] = [];
+    globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+      calls.push(String(input));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          result: {
+            id: 'public-artwork-id',
+            chain: 'ethereum',
+            contractAddress: '0xDB5f1aDCFFA1869B9711cBFBe3Bf46cc5d5319E5',
+            tokenID:
+              '92419109143972345096969611651362597777388673613154609693448331487805624917924',
+          },
+        }),
+      } as Response;
+    };
+
+    const items = await utilities.queryRequirement(
+      {
+        type: 'feral_file_artwork',
+        artworkId: 'public-artwork-id',
+      },
+      10
+    );
+
+    assert.deepEqual(calls, ['https://feralfile.com/api/artworks/public-artwork-id']);
+    assert.equal(items.length, 1);
+    assert.equal(
+      items[0].id,
+      'item-92419109143972345096969611651362597777388673613154609693448331487805624917924'
+    );
   });
 });


### PR DESCRIPTION
## Problem

ff-exhibition#3039 is deployed: `/api/artworks/{id}` now returns self-describing artwork identity fields (`chain`, `contractAddress`, and `tokenID`). The current `main` branch has no clean CLI-side path to consume a Feral File public artwork id or artwork URL without depending on the separate `find` branch.

## Why It Matters

The CLI should use the public Feral File artwork API contract directly for public artwork ids, especially swapped artwork ids where the URL/public id differs from the on-chain token id. This keeps the implementation independent from Sean’s PR #67 while still making the deployed API usable from the CLI.

## Scope

- Adds a standalone Feral File artwork resolver for `/api/artworks/{id}`.
- Adds a `feral_file_artwork` requirement type for structured `build` and AI-assisted `chat` flows.
- Resolves the API response identity fields into existing ff-indexer token lookup coordinates.
- Documents the new requirement in approved docs.
- Adds focused tests for one-call resolution, swapped public ids, missing identity fields, API 404s, and `queryRequirement` wiring.

## Acceptance Checks

1. A `feral_file_artwork` requirement with a public artwork id or `/exhibitions/artwork/{id}` URL resolves through one public artwork API call.
2. Swapped public artwork ids use response `tokenID`, not the public URL id, for indexer lookup.
3. `GROK_API_KEY=dummy npm run verify` passes cleanly.

## Verification

- Live curl confirmed `https://feralfile.com/api/artworks/f0240e04d64717e319584957f6a83954b029254ad1260b6320472ea8c0c5b1cf` returns `chain`, `contractAddress`, and `tokenID`.
- `GROK_API_KEY=dummy ./node_modules/.bin/tsx --test tests/feral-file-artwork.test.ts tests/query-requirement-fallback.test.ts`
- `GROK_API_KEY=dummy npm run verify`

Note: this PR is intentionally branched fresh from `main` and does not include Sean’s `find` branch commits.