### PR TITLE
feat: support verse.works find urls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -146,6 +146,10 @@ Notes:
   - Options: `-k, --key <privateKey>`, `-r, --role <role>`, `-o, --output <file>`
 - `play <source>` – Play a playlist file, playlist URL, or media URL on an FF1 device (runs `verify` before sending; only the CLI-synthesized media URL fallback is auto-signed when a signing key is configured; use `--skip-verify` to bypass the gate)
   - Options: `-d, --device <name>`, `--skip-verify` (skip signature verification; not recommended)
+- `find <input>` – Resolve a marketplace URL, raw `chain:contract:tokenId`, or wallet address into a playable DP-1 playlist
+  - Sources: Art Blocks, Objkt, fxhash, OpenSea, SuperRare, Feral File, Neort, Verse, raw on-chain coordinates, and wallet addresses
+  - Verse forms: `/items/ethereum/{contract}/{tokenId}` and `/series/{slug}`
+  - Options: `-o, --output <path>`, `-l, --limit <n>`, `-p, --play`, `-d, --device <name>`, `--publish`, `-s, --server <index>`, `-y, --yes`, `--skip-verify`
 - `publish <file>` – Publish a playlist to a feed server (runs `verify` before upload and rejects unsigned or broken playlists)
   - Options: `-s, --server <index>` (server index if multiple configured)
 - `ssh <enable|disable>` – Manage SSH access on an FF1 device

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -11,6 +11,7 @@ import { resolveArtBlocksCollection } from '../utilities/ab-marketplace';
 import { resolveFxhashIteration, resolveFxhashProject } from '../utilities/fxhash-marketplace';
 import { resolveNeortArt } from '../utilities/neort-marketplace';
 import type { NeortArt } from '../utilities/neort-marketplace';
+import { resolveVerseSeries } from '../utilities/verse-marketplace';
 import {
   resolveTokenToArtwork,
   getArtworkSummary,
@@ -66,7 +67,7 @@ export const findCommand = new Command('find')
   .description('Find an artwork on the web and build a DP-1 playlist')
   .argument(
     '<input>',
-    'URL (Objkt / fxhash / Art Blocks / OpenSea / SuperRare / Feral File / Neort), `ethereum:{contract}:{tokenId}`, `tezos:{contract}:{tokenId}`, or a wallet address'
+    'URL (Objkt / fxhash / Art Blocks / OpenSea / SuperRare / Feral File / Neort / Verse), `ethereum:{contract}:{tokenId}`, `tezos:{contract}:{tokenId}`, or a wallet address'
   )
   .option('-o, --output <path>', 'Save the playlist to this file (default: ./<slug>.json)')
   .option('-l, --limit <n>', 'Max tokens to include from the series (default: all)')
@@ -91,7 +92,7 @@ export const findCommand = new Command('find')
         console.error(chalk.red('Could not understand input.'));
         console.error(
           chalk.dim(
-            'Supported URLs: Objkt, fxhash, Art Blocks, OpenSea, SuperRare, Feral File, Neort. ' +
+            'Supported URLs: Objkt, fxhash, Art Blocks, OpenSea, SuperRare, Feral File, Neort, Verse. ' +
               'Or: `ethereum:{contract}:{tokenId}`, `tezos:{contract}:{tokenId}`, ' +
               'or a wallet address (`0x...` / `tz1.../tz2.../tz3...`).'
           )
@@ -234,6 +235,10 @@ async function resolveTarget(
   }
   if (parsed.kind === 'fxhash-project') {
     const coords = await resolveFxhashProject(parsed.slug);
+    return resolveCoords(coords);
+  }
+  if (parsed.kind === 'verse-series') {
+    const coords = await resolveVerseSeries(parsed.slug);
     return resolveCoords(coords);
   }
   if (parsed.kind === 'address') {

--- a/src/utilities/marketplace-url.ts
+++ b/src/utilities/marketplace-url.ts
@@ -2,7 +2,7 @@
  * Marketplace URL parser for `ff-cli find`.
  *
  * Accepts user input in any of these forms and returns a normalized result:
- *  - Marketplace token URL (Objkt, fxhash, Art Blocks, OpenSea, SuperRare, Feral File, Neort)
+ *  - Marketplace token URL (Objkt, fxhash, Art Blocks, OpenSea, SuperRare, Feral File, Neort, Verse)
  *  - Raw on-chain coordinates: "ethereum:0xabc...:123" / "tezos:KT1...:456"
  *  - Wallet address: 0x{40-hex} (Ethereum) or tz1/tz2/tz3{33} (Tezos)
  *
@@ -31,7 +31,8 @@ export type MarketplaceSource =
   | 'feralfile'
   | 'opensea'
   | 'superrare'
-  | 'neort';
+  | 'neort'
+  | 'verse';
 
 export type FeralFileUrlKind = 'artwork' | 'series' | 'show';
 
@@ -44,6 +45,7 @@ export type ParsedFindInput =
   | { kind: 'fxhash-iteration'; slug: string }
   | { kind: 'fxhash-project'; slug: string }
   | { kind: 'neort-art'; id: string }
+  | { kind: 'verse-series'; slug: string }
   | { kind: 'unsupported'; reason: string };
 
 const ETH_ADDR = /^0x[a-fA-F0-9]{40}$/;
@@ -121,6 +123,9 @@ export function parseMarketplaceUrl(url: URL): ParsedFindInput | null {
   }
   if (host === 'neort.io' || host.endsWith('.neort.io')) {
     return parseNeort(url);
+  }
+  if (host === 'verse.works' || host.endsWith('.verse.works')) {
+    return parseVerse(url);
   }
   return null;
 }
@@ -377,6 +382,46 @@ export function parseNeort(url: URL): ParsedFindInput {
   return {
     kind: 'unsupported',
     reason: `Neort URL not recognized: ${url.pathname}. Expected /art/{id}.`,
+  };
+}
+
+/**
+ * Verse URL forms:
+ *   verse.works/items/ethereum/{contract}/{tokenId}  — direct Ethereum token
+ *   verse.works/series/{slug}                        — series page
+ *
+ * Verse item pages expose the on-chain coordinates directly in the path. Series
+ * pages do not include a JSON API in the public URL, but they render edition
+ * links with the same `/items/ethereum/...` shape; the async resolver fetches
+ * the series page and extracts a representative token for Raster enumeration.
+ */
+export function parseVerse(url: URL): ParsedFindInput {
+  let m = /^\/items\/ethereum\/(0x[a-fA-F0-9]{40})\/(\d+)\/?$/.exec(url.pathname);
+  if (m) {
+    return {
+      kind: 'token',
+      source: 'verse',
+      coords: { chain: 'ethereum', contract: m[1].toLowerCase(), tokenId: m[2] },
+    };
+  }
+  m = /^\/items\/([^/]+)\//.exec(url.pathname);
+  if (m) {
+    return {
+      kind: 'unsupported',
+      reason:
+        `Verse ${m[1]} item URLs are not supported — ff-cli covers Ethereum and Tezos mainnet only. ` +
+        'Paste an Ethereum Verse item URL or raw `ethereum:{contract}:{tokenId}` coordinates.',
+    };
+  }
+  m = /^\/series\/([A-Za-z0-9][A-Za-z0-9_-]*)\/?$/.exec(url.pathname);
+  if (m) {
+    return { kind: 'verse-series', slug: m[1] };
+  }
+  return {
+    kind: 'unsupported',
+    reason:
+      `Verse URL not recognized: ${url.pathname}. Expected ` +
+      '/items/ethereum/{contract}/{tokenId} or /series/{slug}.',
   };
 }
 

--- a/src/utilities/verse-marketplace.ts
+++ b/src/utilities/verse-marketplace.ts
@@ -1,0 +1,36 @@
+import type { TokenCoords } from './marketplace-url';
+
+/**
+ * Resolve a Verse series slug to representative Ethereum token coordinates.
+ *
+ * Verse series pages render edition links as
+ * `/items/ethereum/{contract}/{tokenId}`. Using the first rendered edition
+ * keeps the resolver independent of private frontend state while still handing
+ * Raster a token it can use to enumerate the full series.
+ *
+ * @param slug - Verse series slug from `/series/{slug}`
+ * @returns Representative Ethereum token coordinates
+ * @throws Error when the page cannot be fetched or no Ethereum edition link is present
+ */
+export async function resolveVerseSeries(slug: string): Promise<TokenCoords> {
+  const url = `https://verse.works/series/${encodeURIComponent(slug)}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Verse series lookup failed for ${slug}: ${response.status}`);
+  }
+
+  const html = await response.text();
+  const match = /\/items\/ethereum\/(0x[a-fA-F0-9]{40})\/(\d+)/.exec(html);
+  if (!match) {
+    throw new Error(
+      `Verse series ${slug} did not expose an Ethereum edition link. ` +
+        'Paste a specific Verse item URL or raw `ethereum:{contract}:{tokenId}` coordinates.'
+    );
+  }
+
+  return {
+    chain: 'ethereum',
+    contract: match[1].toLowerCase(),
+    tokenId: match[2],
+  };
+}

--- a/tests/find-resolvers.test.ts
+++ b/tests/find-resolvers.test.ts
@@ -20,6 +20,7 @@ import { resolveObjktAlias } from '../src/utilities/objkt-marketplace';
 import { resolveFxhashIteration, resolveFxhashProject } from '../src/utilities/fxhash-marketplace';
 import { resolveNeortArt } from '../src/utilities/neort-marketplace';
 import { resolveFeralFileToken } from '../src/utilities/ff-marketplace';
+import { resolveVerseSeries } from '../src/utilities/verse-marketplace';
 import { resolveTokenToArtwork, listArtworkTokens } from '../src/utilities/raster-client';
 
 type FetchFn = typeof global.fetch;
@@ -466,6 +467,40 @@ describe('resolveNeortArt', () => {
     await assert.rejects(
       () => withMockedFetch(mock, () => resolveNeortArt('broken123')),
       /no playable asset/
+    );
+  });
+});
+
+describe('resolveVerseSeries', () => {
+  test('happy: series page → first Ethereum edition link coords', async () => {
+    const mock = (async () =>
+      new Response(
+        '<html><a href="/items/ethereum/0x23b72f7458a204446983f544d655df10f70533e9/139">Quantizer</a></html>',
+        { status: 200, headers: { 'Content-Type': 'text/html' } }
+      )) as FetchFn;
+
+    const coords = await withMockedFetch(mock, () =>
+      resolveVerseSeries('quantizer-by-harm-van-den-dorpel')
+    );
+    assert.equal(coords.chain, 'ethereum');
+    assert.equal(coords.contract, '0x23b72f7458a204446983f544d655df10f70533e9');
+    assert.equal(coords.tokenId, '139');
+  });
+
+  test('series page with no Ethereum edition links → throws with item URL hint', async () => {
+    const mock = (async () =>
+      new Response('<html>No items yet</html>', { status: 200 })) as FetchFn;
+    await assert.rejects(
+      () => withMockedFetch(mock, () => resolveVerseSeries('empty-series')),
+      /specific Verse item URL/
+    );
+  });
+
+  test('HTTP error → throws with status', async () => {
+    const mock = (async () => new Response('Not found', { status: 404 })) as FetchFn;
+    await assert.rejects(
+      () => withMockedFetch(mock, () => resolveVerseSeries('does-not-exist')),
+      /404/
     );
   });
 });

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -254,6 +254,38 @@ describe('parseFindInput', () => {
     assert.ok(r.reason.includes('/art/'));
   });
 
+  test('Verse item URL → token kind, source verse', () => {
+    const r = parseFindInput(
+      'https://verse.works/items/ethereum/0x23b72f7458a204446983f544d655df10f70533e9/139'
+    );
+    assert.equal(r?.kind, 'token');
+    if (r?.kind !== 'token') {
+      throw new Error('narrowing');
+    }
+    assert.equal(r.source, 'verse');
+    assert.equal(r.coords.chain, 'ethereum');
+    assert.equal(r.coords.contract, '0x23b72f7458a204446983f544d655df10f70533e9');
+    assert.equal(r.coords.tokenId, '139');
+  });
+
+  test('Verse series URL → verse-series kind', () => {
+    const r = parseFindInput('https://verse.works/series/quantizer-by-harm-van-den-dorpel');
+    assert.equal(r?.kind, 'verse-series');
+    if (r?.kind !== 'verse-series') {
+      throw new Error('narrowing');
+    }
+    assert.equal(r.slug, 'quantizer-by-harm-van-den-dorpel');
+  });
+
+  test('Verse unsupported item chain → unsupported with chain hint', () => {
+    const r = parseFindInput('https://verse.works/items/base/0xabc/1');
+    assert.equal(r?.kind, 'unsupported');
+    if (r?.kind !== 'unsupported') {
+      throw new Error('narrowing');
+    }
+    assert.ok(r.reason.includes('base'));
+  });
+
   test('SuperRare /collection/{contract} URL → unsupported with specific message', () => {
     const r = parseFindInput(
       'https://superrare.com/collection/0x3e930455dcBf4bC69DE9926bDAF8ef782398786f'


### PR DESCRIPTION
## Problem

`ff-cli find` did not recognize `verse.works` URLs, so users had to manually extract raw on-chain coordinates before building DP-1 playlists from Verse works or series.

## Why It Matters

Verse publishes computational art with stable item URLs that include Ethereum token coordinates, and series pages expose edition links that Raster can use to enumerate a full series. Supporting those URLs keeps Verse beside the existing marketplace sources in the find workflow.

## What Changed

- Parse Verse item URLs in the form `/items/ethereum/{contract}/{tokenId}`.
- Resolve Verse series URLs by fetching the series page and extracting the first Ethereum edition link as the representative Raster token.
- Update CLI supported-source text, README usage, and parser/resolver tests.

## Acceptance Checks

- `npm test -- tests/find.test.ts tests/find-resolvers.test.ts`
- `ANTHROPIC_API_KEY=dummy npm run verify`
- Live smoke: `ff-cli find https://verse.works/series/quantizer-by-harm-van-den-dorpel --limit 1 --output .tmp/verse-quantizer.json --yes` resolved Quantizer and saved a one-item playlist.

## Remaining Risks

Verse series resolution depends on public series HTML continuing to expose `/items/ethereum/...` edition links.