### PR TITLE
[codex] fix token standard mapping

### DIFF
--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -354,6 +354,7 @@ function mapIndexerDataToStandardFormat(indexerData, chain) {
   const artistName = extractArtistName(display.artists);
   const name = display.name || `Token #${indexerData.token_number}`;
   const description = display.description || '';
+  const standard = detectTokenStandard(chain, indexerData.contract_address);
 
   return {
     success: true,
@@ -361,6 +362,7 @@ function mapIndexerDataToStandardFormat(indexerData, chain) {
       chain,
       contractAddress: indexerData.contract_address,
       tokenId: indexerData.token_number,
+      standard,
       name,
       description,
       image: {
@@ -487,7 +489,7 @@ function convertToDP1Item(tokenData, duration = 10) {
       type: 'onChain',
       contract: {
         chain: chainMap[token.chain.toLowerCase()] || 'other',
-        standard: 'other',
+        standard: token.standard || detectTokenStandard(token.chain, token.contractAddress),
         address: token.contractAddress,
         tokenId: String(token.tokenId),
       },

--- a/tests/nft-indexer.test.ts
+++ b/tests/nft-indexer.test.ts
@@ -191,6 +191,50 @@ test('mapIndexerDataToStandardFormat: handles missing display gracefully', () =>
   assert.equal(out.token.metadata.artistName, '');
 });
 
+test('mapIndexerDataToStandardFormat: infers erc721 for ethereum tokens and preserves it in DP1 output', () => {
+  const { mapIndexerDataToStandardFormat, convertToDP1Item } = nftIndexer;
+  const tokenRow = mockTokenRow({
+    contract_address: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+    token_number: '7804',
+  });
+
+  const out = mapIndexerDataToStandardFormat(tokenRow, 'ethereum');
+  assert.equal(out.success, true);
+  if (!('token' in out) || !out.token) {
+    assert.fail('expected token on success');
+  }
+  assert.equal(out.token.standard, 'erc721');
+
+  const dp1 = convertToDP1Item(out, 10);
+  assert.equal(dp1.success, true);
+  if (!('item' in dp1) || !dp1.item) {
+    assert.fail('expected item on success');
+  }
+  assert.equal(dp1.item.provenance.contract.standard, 'erc721');
+});
+
+test('mapIndexerDataToStandardFormat: infers fa2 for Tezos KT contracts and preserves it in DP1 output', () => {
+  const { mapIndexerDataToStandardFormat, convertToDP1Item } = nftIndexer;
+  const tokenRow = mockTokenRow({
+    contract_address: 'KT1abcdef1234567890abcdef1234567890abcdef',
+    token_number: '42',
+  });
+
+  const out = mapIndexerDataToStandardFormat(tokenRow, 'tezos');
+  assert.equal(out.success, true);
+  if (!('token' in out) || !out.token) {
+    assert.fail('expected token on success');
+  }
+  assert.equal(out.token.standard, 'fa2');
+
+  const dp1 = convertToDP1Item(out, 10);
+  assert.equal(dp1.success, true);
+  if (!('item' in dp1) || !dp1.item) {
+    assert.fail('expected item on success');
+  }
+  assert.equal(dp1.item.provenance.contract.standard, 'fa2');
+});
+
 test('mapIndexerDataToStandardFormat: returns error for null indexerData', () => {
   const { mapIndexerDataToStandardFormat } = nftIndexer;
   const out = mapIndexerDataToStandardFormat(null, 'ethereum');


### PR DESCRIPTION
## Summary
Fix token standard inference in the FF1 playlist build path so Raster-derived DP-1 items no longer default `provenance.contract.standard` to `other`.

## Root Cause
`src/utilities/nft-indexer.js` was constructing DP-1 items with a hardcoded `standard: 'other'` even when the token chain/contract format already implied `erc721` or `fa2`.

## Change
- Add `standard` to the normalized token record returned by the Raster/indexer mapper.
- Use that inferred value when building the DP-1 provenance contract.

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run test`

## Notes
This fixes the output for Raster-derived playlists built through `ff-cli find` and keeps the source and published binary logic aligned.
