### PR TITLE
fix: play video/audio at natural length when no duration is given (DP-1 §4.1)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,7 +26,8 @@ npm run dev -- config show
   - Used by orchestration to pick API, timeouts, and model identifier.
 
 - **defaultDuration** (number, seconds)
-  - Intended default per‑item display duration. Some flows pass an explicit duration; when omitted, utilities fall back to 10s.
+  - Default per‑item display duration for media without an intrinsic runtime (images, code-based works). Falls back to 10s when unset.
+  - Does NOT apply to video/audio items: with no explicit duration those are emitted without `duration` and with `display.loop: false`, so a DP-1 player advances at end-of-stream (§4.1) — the media plays its natural length.
 
 ## models
 

--- a/docs/FUNCTION_CALLING.md
+++ b/docs/FUNCTION_CALLING.md
@@ -75,11 +75,13 @@ Two options are available:
       "quantity": 2
     }
   ],
-  "playlistSettings": { "durationPerItem": 10, "preserveOrder": true, "title": "My Mix" }
+  "playlistSettings": { "preserveOrder": true, "title": "My Mix" }
 }
 ```
 
 This path bypasses the intent parser/orchestrator and calls utilities directly. Validation and sensible defaults are applied in `src/main.ts`.
+
+`playlistSettings.durationPerItem` is optional. Omit it for auto timing: video/audio items are emitted without `duration` and with `display.loop: false`, so a DP-1 player advances at end-of-stream (§4.1) and the media plays its natural length; static items fall back to `defaultDuration`. Set `durationPerItem` only to force a fixed display time on every item.
 
 2. AI‑orchestrated deterministic build (recommended for prompts): Use `chat` with `--verbose` to see tool calls. The orchestrator enforces complete requirement objects, then runs `verify_playlist` (structure only) before sending.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -343,7 +343,7 @@ Setup preserves existing devices when adding new ones. See selection rules and e
 
 - Max 20 items total across all requirements
 - Per-source caps enforced in utilities
-- Duration per item defaults to 10s (configurable)
+- Per-item timing: when no duration is given, video/audio items carry **no** `duration` and `display.loop: false`, so the player advances at end-of-stream (DP-1 §4.1) — the media plays its natural length. Static items use `defaultDuration` (10s unless configured). An explicit duration always wins.
 
 ## Links
 

--- a/src/ai-orchestrator/index.js
+++ b/src/ai-orchestrator/index.js
@@ -80,17 +80,20 @@ function inferToolCallFromContent(content, iterationCount) {
         typeof parsed === 'object' &&
         parsed.requirement &&
         typeof parsed.requirement === 'object' &&
-        typeof parsed.duration === 'number'
+        (parsed.duration === undefined || typeof parsed.duration === 'number')
       ) {
+        // duration is optional: absent means auto timing (DP-1 §4.1), so the
+        // synthetic call must not fabricate one.
+        const syntheticArgs = { requirement: parsed.requirement };
+        if (typeof parsed.duration === 'number') {
+          syntheticArgs.duration = parsed.duration;
+        }
         return {
           id: `synthetic_query_requirement_${iterationCount}`,
           type: 'function',
           function: {
             name: 'query_requirement',
-            arguments: JSON.stringify({
-              requirement: parsed.requirement,
-              duration: parsed.duration,
-            }),
+            arguments: JSON.stringify(syntheticArgs),
           },
         };
       }
@@ -188,10 +191,11 @@ const functionSchemas = [
           },
           duration: {
             type: 'number',
-            description: 'Display duration per item in seconds',
+            description:
+              'Display duration per item in seconds. Omit for auto timing: video/audio items then carry no duration and play their natural length (DP-1 §4.1); static items use the configured default.',
           },
         },
-        required: ['requirement', 'duration'],
+        required: ['requirement'],
       },
     },
   },
@@ -232,10 +236,10 @@ const functionSchemas = [
           },
           duration: {
             type: 'number',
-            description: 'Duration per item in seconds',
+            description: "Duration per item in seconds. Omit to keep each feed item's own timing.",
           },
         },
-        required: ['playlistName', 'quantity', 'duration'],
+        required: ['playlistName', 'quantity'],
       },
     },
   },
@@ -534,6 +538,14 @@ function buildOrchestratorSystemPrompt(params) {
     })
     .join('\n');
 
+  // Spell out the duration argument once: an explicit setting is passed
+  // through verbatim; otherwise the model must OMIT duration so item-build
+  // applies auto timing (video/audio natural length per DP-1 §4.1).
+  const durationArgText =
+    typeof playlistSettings.durationPerItem === 'number'
+      ? `call query_requirement(requirement, duration=${playlistSettings.durationPerItem}).`
+      : 'call query_requirement(requirement) WITHOUT a duration argument (auto timing).';
+
   const hasDevice = playlistSettings.deviceName !== undefined;
   const sendStep = hasDevice
     ? `6) If verification passed → you MUST call send_to_device({ playlistId: <the_playlistId>, deviceName: "${playlistSettings.deviceName || 'first-device'}" }) before finishing.
@@ -549,7 +561,7 @@ REQUIREMENTS
 ${requirementsText}
 
 PLAYLIST SETTINGS
-- durationPerItem: ${playlistSettings.durationPerItem || 10}
+- durationPerItem: ${typeof playlistSettings.durationPerItem === 'number' ? playlistSettings.durationPerItem : 'auto (omit duration: video/audio play natural length, static media uses configured default)'}
 - title: ${playlistSettings.title || 'auto'}
 - slug: ${playlistSettings.slug || 'auto'}
 - preserveOrder: ${playlistSettings.preserveOrder !== false ? 'true' : 'false'}
@@ -578,14 +590,14 @@ KEY RULES
 
 DECISION LOOP
 1) For each requirement in order:
-   - build_playlist: call query_requirement(requirement, duration=${playlistSettings.durationPerItem || 10}).
+   - build_playlist: ${durationArgText}
      Returns array with minimal item data including id field. Collect the id values.
-   - feral_file_artwork: call query_requirement(requirement, duration=${playlistSettings.durationPerItem || 10}).
+   - feral_file_artwork: ${durationArgText}
      Returns array with minimal item data including id field. Collect the id values.
    - query_address:
      • if ownerAddress endsWith .eth/.tez → resolve_domains([domain]); if resolved → use returned address; if not → mark failed and continue.
-     • if ownerAddress is 0x…/tz… → call query_requirement(requirement, duration=${playlistSettings.durationPerItem || 10}).
-   - fetch_feed: search_feed_playlist(name) → take bestMatch → fetch_feed_playlist_items(bestMatch, quantity, duration=${playlistSettings.durationPerItem || 10}).
+     • if ownerAddress is 0x…/tz… → ${durationArgText}
+   - fetch_feed: search_feed_playlist(name) → take bestMatch → fetch_feed_playlist_items(bestMatch, quantity${typeof playlistSettings.durationPerItem === 'number' ? `, duration=${playlistSettings.durationPerItem}` : ''}).
    - Collect item IDs across all steps in an array (let's call it collectedItemIds).
 2) If zero items → explain briefly and finish.
 3) If some requirements failed and interactive mode → ask user; otherwise proceed with available items.

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -158,7 +158,8 @@ export const findCommand = new Command('find')
 
       // Second positional arg on getNFTTokenInfoBatch is `duration` (DP-1 item
       // display seconds), not concurrency — concurrency is hardcoded inside.
-      // Omit it so the default (10s) applies; no misleading constant on this side.
+      // Omit it for auto timing: video/audio items carry no duration and play
+      // their natural length (DP-1 §4.1); static items get the config default.
       const items = await getNFTTokenInfoBatch(
         tokens.map((t) => ({
           chain: t.chain,
@@ -593,7 +594,8 @@ async function runNeortFind(id: string, options: FindOptions): Promise<void> {
     return;
   }
 
-  const item = buildUrlItem(art.assetUrl, 10, { title: art.title });
+  // No explicit duration: auto timing (video/audio play natural length).
+  const item = buildUrlItem(art.assetUrl, undefined, { title: art.title });
   const playlistTitle = `${artistLabel} — ${art.title}`;
   const playlist = await buildDP1Playlist({ items: [item], title: playlistTitle });
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -24,7 +24,9 @@ export const playCommand = new Command('play')
   .action(async (source: string, options: { device?: string; skipVerify?: boolean }) => {
     try {
       const config = getConfig();
-      const resolved = await resolvePlaySource(source, config.defaultDuration || 10);
+      // No explicit duration: a direct video/audio URL plays its natural
+      // length (DP-1 §4.1); static media uses config.defaultDuration.
+      const resolved = await resolvePlaySource(source);
       const isPlaylistSource = resolved.kind === 'playlist';
       const sourceLabel = isPlaylistSource
         ? `${resolved.sourceType}: ${resolved.source}`

--- a/src/intent-parser/index.ts
+++ b/src/intent-parser/index.ts
@@ -160,7 +160,7 @@ EXAMPLES (fetch_feed)
 - "Pick 3 artworks from Social Codes and 2 from a2p. Mix them up." → \`fetch_feed\` { playlistName: "Social Codes", quantity: 3 } + \`fetch_feed\` { playlistName: "a2p", quantity: 2 }, and set \`playlistSettings.preserveOrder\` = false
 
 PLAYLIST SETTINGS EXTRACTION
-- durationPerItem: parse phrases (e.g., "6 seconds each" → 6)
+- durationPerItem: parse phrases (e.g., "6 seconds each" → 6); OMIT entirely when the user gives no per-item time — omitted means auto timing (video/audio play their natural length, static media uses the configured default). Never invent a number.
 - preserveOrder: default true; synonyms ("shuffle", "randomize", "mix", "mix them up", "scramble") → false
 - title/slug: optional; include only if provided by the user
 - deviceName: from phrases like "send to", "display on", "play on", "push to"${hasDevices ? '\n- available devices:\n' + deviceInfo.replace('\n\nAVAILABLE FF1 DEVICES:\n', '') : ''}
@@ -349,7 +349,8 @@ const intentParserFunctionSchemas: OpenAI.Chat.ChatCompletionTool[] = [
               },
               durationPerItem: {
                 type: 'number',
-                description: 'Duration per item in seconds (e.g., 5 for "5 seconds each")',
+                description:
+                  'Duration per item in seconds (e.g., 5 for "5 seconds each"). Omit when the user gives no per-item time: omitted = auto timing (video/audio play natural length per DP-1 §4.1).',
               },
               totalDuration: {
                 type: 'number',

--- a/src/intent-parser/utils.ts
+++ b/src/intent-parser/utils.ts
@@ -17,10 +17,12 @@ interface RequirementParams {
  * @param {Object} params - Parsed parameters
  * @param {Array<Object>} params.requirements - Array of requirements
  * @param {Object} [params.playlistSettings] - Playlist settings
- * @param {Object} config - Application config
+ * @param {Object} _config - Application config (kept in the signature for
+ *   call-site stability; no constraint reads it since durationPerItem
+ *   pre-filling was removed in favor of DP-1 §4.1 auto timing)
  * @returns {Object} Validated parameters
  */
-export function applyConstraints(params: RequirementParams, config: Config): RequirementParams {
+export function applyConstraints(params: RequirementParams, _config: Config): RequirementParams {
   // Validate requirements array
   if (!params.requirements || !Array.isArray(params.requirements)) {
     throw new Error('Requirements must be an array');
@@ -112,10 +114,11 @@ export function applyConstraints(params: RequirementParams, config: Config): Req
     params.playlistSettings = {};
   }
 
-  // Only set durationPerItem if not already specified
-  if (params.playlistSettings.durationPerItem === undefined) {
-    params.playlistSettings.durationPerItem = config.defaultDuration || 10;
-  }
+  // durationPerItem stays undefined unless the user asked for a per-item
+  // time: absence means auto timing downstream (video/audio omit duration
+  // and play their natural length per DP-1 §4.1; static media falls back to
+  // config.defaultDuration at item-build time). Pre-filling a number here
+  // would force-cut every video item.
 
   // Only set preserveOrder if not already specified
   if (params.playlistSettings.preserveOrder === undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,12 +252,14 @@ export function validateRequirements(requirements: Requirement[]): Requirement[]
  * @returns {Object} Settings with defaults
  */
 export function applyPlaylistDefaults(settings: Partial<PlaylistSettings> = {}): PlaylistSettings {
-  const config = getConfig();
-
   return {
     title: settings.title || null,
     slug: settings.slug || null,
-    durationPerItem: settings.durationPerItem || config.defaultDuration || 10,
+    // Leave durationPerItem undefined when not requested: absence means auto
+    // timing downstream (video/audio omit duration and play their natural
+    // length per DP-1 §4.1; static media falls back to config.defaultDuration
+    // at item-build time). Filling a number here would force-cut video items.
+    durationPerItem: settings.durationPerItem,
     preserveOrder: settings.preserveOrder !== false,
     deviceName: settings.deviceName,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,9 @@ export interface Playlist {
 export interface PlaylistSettings {
   title: string | null;
   slug: string | null;
-  durationPerItem: number;
+  // Undefined = auto timing: video/audio items omit duration and play their
+  // natural length (DP-1 §4.1); static items use config.defaultDuration.
+  durationPerItem?: number;
   preserveOrder: boolean;
   deviceName?: string;
   feedServer?: { baseUrl: string; apiKey?: string };

--- a/src/utilities/feed-fetcher.js
+++ b/src/utilities/feed-fetcher.js
@@ -382,7 +382,7 @@ function shuffleArray(array) {
  *
  * @param {Object} playlist - DP1 playlist object
  * @param {number} quantity - Number of items to extract
- * @param {number} duration - Duration per item in seconds
+ * @param {number} [duration] - Explicit display seconds; omit to keep item timing
  * @param {boolean} shuffle - Whether to shuffle and randomly select items
  * @returns {Array<Object>} Array of DP1 playlist items
  */
@@ -401,12 +401,19 @@ function extractPlaylistItems(playlist, quantity, duration, shuffle = true) {
   // Take requested quantity
   items = items.slice(0, quantity);
 
-  // Override duration and ensure created field exists
-  items = items.map((item) => ({
-    ...item,
-    duration: duration || item.duration,
-    created: item.created || new Date().toISOString(), // Ensure created field exists
-  }));
+  // Apply an explicit duration override when one was requested; otherwise
+  // keep each item's own timing (including intentionally absent duration,
+  // which DP-1 §4.1 uses for natural-length playback of video/audio).
+  items = items.map((item) => {
+    const next = {
+      ...item,
+      created: item.created || new Date().toISOString(), // Ensure created field exists
+    };
+    if (typeof duration === 'number') {
+      next.duration = duration;
+    }
+    return next;
+  });
 
   return items;
 }
@@ -416,10 +423,10 @@ function extractPlaylistItems(playlist, quantity, duration, shuffle = true) {
  *
  * @param {string} playlistName - Exact playlist name
  * @param {number} quantity - Number of items to fetch
- * @param {number} duration - Duration per item
+ * @param {number} [duration] - Explicit display seconds; omit to keep item timing
  * @returns {Promise<Object>} Result with items
  */
-async function fetchFeedPlaylistDirect(playlistName, quantity = 5, duration = 10) {
+async function fetchFeedPlaylistDirect(playlistName, quantity = 5, duration) {
   const feedUrls = getFeedApiUrls();
   console.log(
     chalk.cyan(`Searching for playlist "${playlistName}" in ${feedUrls.length} source(s)...`)
@@ -457,10 +464,10 @@ async function fetchFeedPlaylistDirect(playlistName, quantity = 5, duration = 10
  *
  * @param {string} playlistName - Playlist name (can be fuzzy)
  * @param {number} quantity - Number of items to fetch
- * @param {number} duration - Duration per item
+ * @param {number} [duration] - Explicit display seconds; omit to keep item timing
  * @returns {Promise<Object>} Result with best match and map for lookup
  */
-async function searchFeedPlaylists(playlistName, quantity = 5, duration = 10) {
+async function searchFeedPlaylists(playlistName, quantity = 5, duration) {
   const feedUrls = getFeedApiUrls();
   console.log(
     chalk.cyan(`Searching for playlist "${playlistName}" in ${feedUrls.length} source(s)...`)
@@ -496,7 +503,7 @@ async function searchFeedPlaylists(playlistName, quantity = 5, duration = 10) {
  *
  * @param {string} playlistIdOrName - Playlist ID, slug, or exact name
  * @param {number} quantity - Number of items to fetch
- * @param {number} duration - Duration per item
+ * @param {number} [duration] - Explicit display seconds; omit to keep item timing
  * @param {Object} playlistMap - Optional map of names to IDs for lookup
  * @param {boolean} shuffle - Whether to shuffle and randomly select items
  * @returns {Promise<Object>} Result with items
@@ -504,7 +511,7 @@ async function searchFeedPlaylists(playlistName, quantity = 5, duration = 10) {
 async function fetchPlaylistItems(
   playlistIdOrName,
   quantity = 5,
-  duration = 10,
+  duration,
   playlistMap = null,
   shuffle = true
 ) {

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -70,10 +70,10 @@ function isLikelyEvmAddress(address) {
  *
  * @param {string} contractAddress - Contract address
  * @param {number|string} [quantity] - Number of random tokens to select
- * @param {number} duration - Duration per item in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
  * @returns {Promise<Array<Object>>} Array of DP1 items
  */
-async function queryTokensByContractAddress(contractAddress, quantity, duration = 10) {
+async function queryTokensByContractAddress(contractAddress, quantity, duration) {
   console.log(
     chalk.cyan(
       `   Fetching ${quantity || 100} random token(s) from contract ${contractAddress.substring(0, 10)}...`
@@ -133,10 +133,10 @@ function initializeUtilities(_config) {
  *
  * @param {string} ownerAddress - Owner wallet address
  * @param {number|string} [quantity] - Number of random tokens to select, or "all" to fetch all tokens
- * @param {number} duration - Duration per item in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
  * @returns {Promise<Array>} Array of DP1 playlist items
  */
-async function queryTokensByAddress(ownerAddress, quantity, duration = 10, options = {}) {
+async function queryTokensByAddress(ownerAddress, quantity, duration, options = {}) {
   try {
     const { suppressNotFoundGuidance = false } = options;
     const shouldFetchAll = quantity === 'all' || quantity === undefined || quantity === null;
@@ -237,7 +237,7 @@ async function queryTokensByAddress(ownerAddress, quantity, duration = 10, optio
       selectedTokens = shuffleArray([...selectedTokens]).slice(0, quantity);
     }
 
-    const tokenCountKey = `${ownerAddress}|${quantity ?? 'all'}|${duration}`;
+    const tokenCountKey = `${ownerAddress}|${quantity ?? 'all'}|${duration ?? 'auto'}`;
     if (!printedTokenCountKeys.has(tokenCountKey)) {
       console.log(chalk.dim(`Got ${selectedTokens.length} token(s)`));
       printedTokenCountKeys.add(tokenCountKey);
@@ -271,10 +271,10 @@ async function queryTokensByAddress(ownerAddress, quantity, duration = 10, optio
  * @param {string} [requirement.ownerAddress] - Owner address (for query_address)
  * @param {string} [requirement.playlistName] - Feed playlist name (for fetch_feed)
  * @param {number} [requirement.quantity] - Number of items
- * @param {number} duration - Duration per item in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
  * @returns {Promise<Array>} Array of DP1 playlist items
  */
-async function queryRequirement(requirement, duration = 10) {
+async function queryRequirement(requirement, duration) {
   const {
     type,
     blockchain,
@@ -532,7 +532,9 @@ async function buildPlaylistDirect(params, options = {}) {
   const { verbose = false, outputPath = 'playlist.json' } = options;
 
   const allItems = [];
-  const duration = playlistSettings.durationPerItem || 10;
+  // Undefined means auto timing: video/audio items omit duration and play
+  // their natural length (DP-1 §4.1); static items get the configured default.
+  const duration = playlistSettings.durationPerItem;
 
   console.log(chalk.cyan('\nBuilding playlist from your requirements...\n'));
 

--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -6,6 +6,7 @@
 
 const GRAPHQL_ENDPOINT = 'https://indexer.feralfile.com/graphql';
 const logger = require('../logger');
+const { applyItemTiming } = require('./playlist-builder');
 
 // Polling configuration (in milliseconds)
 const POLLING_INTERVAL_MS = 2000; // Poll every 2 seconds
@@ -392,10 +393,11 @@ function mapIndexerDataToStandardFormat(indexerData, chain) {
  * animation_url > image.url, ensuring the best quality media is used.
  *
  * @param {Object} tokenData - Token data in standard format
- * @param {number} duration - Display duration in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
+ *   (video/audio play natural length per DP-1 §4.1)
  * @returns {Object} DP1 item with source URL from indexer
  */
-function convertToDP1Item(tokenData, duration = 10) {
+function convertToDP1Item(tokenData, duration) {
   const { token } = tokenData;
 
   if (!token) {
@@ -482,7 +484,6 @@ function convertToDP1Item(tokenData, duration = 10) {
   const dp1Item = {
     id: itemId,
     source: sourceUrl,
-    duration: duration,
     license: 'open',
     created: new Date().toISOString(),
     provenance: {
@@ -501,6 +502,8 @@ function convertToDP1Item(tokenData, duration = 10) {
     dp1Item.title = token.name;
   }
 
+  applyItemTiming(dp1Item, { mimeType: token.image?.mimeType, sourceUrl }, duration);
+
   logger.debug('[NFT Indexer] ✓ Converted to DP1:', {
     title: token.name,
     source: sourceUrl ? sourceUrl.substring(0, 60) + '...' : '(no source URL)',
@@ -515,11 +518,11 @@ function convertToDP1Item(tokenData, duration = 10) {
 /**
  * Get NFT token information from indexer and return as DP1 item (supports single or batch)
  * @param {Object|Array} params - Token parameters (single object or array)
- * @param {number} duration - Display duration in seconds (default: 10)
+ * @param {number} [params.duration] - Explicit display seconds; omit for auto timing
  * @returns {Promise<Object>} DP1 item(s)
  */
 async function getNFTTokenInfo(params) {
-  const duration = params.duration || 10;
+  const duration = params.duration;
 
   // Handle array input for batch processing
   if (Array.isArray(params.tokens)) {
@@ -549,7 +552,7 @@ async function getNFTTokenInfo(params) {
  * @param {Object} [options.mediaPoll] - Passed to pollForMediaAssets
  * @returns {Promise<Object>} DP1 item with success/error status
  */
-async function getNFTTokenInfoSingle(params, duration = 10, options = {}) {
+async function getNFTTokenInfoSingle(params, duration, options = {}) {
   let chain = params.chain;
   const { contractAddress, tokenId } = params;
 
@@ -672,7 +675,7 @@ async function getNFTTokenInfoSingle(params, duration = 10, options = {}) {
  * @param {number} duration - Display duration in seconds
  * @returns {Promise<Array>} Array of DP1 items
  */
-async function getNFTTokenInfoBatch(tokens, duration = 10) {
+async function getNFTTokenInfoBatch(tokens, duration) {
   logger.info(`[NFT Indexer] 📦 Starting batch processing for ${tokens.length} token(s)...`);
   logger.debug('[NFT Indexer] Batch tokens:', tokens);
 

--- a/src/utilities/playlist-builder.js
+++ b/src/utilities/playlist-builder.js
@@ -3,8 +3,76 @@
  * Core functions for building and validating DP1 playlists
  */
 
-const { getPlaylistConfig } = require('../config');
+const { getPlaylistConfig, getConfig } = require('../config');
 const { signPlaylist } = require('./playlist-signer');
+
+/**
+ * isTimeBasedMedia reports whether an item's media has an intrinsic runtime
+ * (video or audio) per DP-1 §4.1 "time-based sources".
+ *
+ * Two signals are consulted because neither is reliable alone: indexer
+ * `display.mime_type` is authoritative when present but is defaulted to
+ * 'image/png' upstream when missing, and URL extensions only cover direct
+ * media links. Either signal saying video/audio wins.
+ *
+ * @param {string} [mimeType] - MIME type reported by the indexer, if any
+ * @param {string} [sourceUrl] - Item source URL, used as an extension fallback
+ * @returns {boolean} True when the media is video or audio
+ */
+function isTimeBasedMedia(mimeType, sourceUrl) {
+  const candidates = [String(mimeType || '').toLowerCase(), detectMimeType(sourceUrl)];
+  return candidates.some((mime) => mime.startsWith('video/') || mime.startsWith('audio/'));
+}
+
+/**
+ * applyItemTiming sets a DP1 item's playback timing per DP-1 §4.1.
+ *
+ * Invariant this function owns: an explicit numeric `duration` always wins
+ * and is stamped as-is. When `duration` is undefined/null ("auto"), a
+ * time-based source (video/audio) gets NO duration and `display.loop: false`,
+ * so a conformant player MUST advance at end-of-stream — the media plays its
+ * natural length. Static and code-based sources fall back to the configured
+ * `defaultDuration` because they have no intrinsic runtime to play out.
+ *
+ * Do not re-introduce an unconditional duration here: stamping a default on
+ * video items silently truncates or pads them (the bug this fixed).
+ *
+ * @param {Object} item - DP1 playlist item (mutated in place)
+ * @param {Object} mediaHints - Media signals for the time-based check
+ * @param {string} [mediaHints.mimeType] - Indexer-reported MIME type
+ * @param {string} [mediaHints.sourceUrl] - Item source URL
+ * @param {number} [duration] - Explicit display seconds; omit for auto
+ * @returns {Object} The same item, for chaining
+ */
+function applyItemTiming(item, mediaHints = {}, duration) {
+  if (typeof duration === 'number') {
+    item.duration = duration;
+    return item;
+  }
+
+  if (isTimeBasedMedia(mediaHints.mimeType, mediaHints.sourceUrl)) {
+    item.display = { ...(item.display || {}), loop: false };
+    return item;
+  }
+
+  item.duration = getDefaultStaticDuration();
+  return item;
+}
+
+/**
+ * getDefaultStaticDuration returns the configured per-item display seconds
+ * for media without an intrinsic runtime. Falls back to 10 when config is
+ * unavailable (e.g. unit tests without a config file).
+ *
+ * @returns {number} Display duration in seconds
+ */
+function getDefaultStaticDuration() {
+  try {
+    return getConfig().defaultDuration || 10;
+  } catch (_error) {
+    return 10;
+  }
+}
 
 /**
  * Convert a string to a URL-friendly slug
@@ -34,14 +102,16 @@ function slugify(value) {
  * Convert single NFT token info to DP1 playlist item
  *
  * @param {Object} tokenInfo - Token information from NFT indexer
- * @param {number} duration - Display duration in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
+ *   (video/audio play natural length per DP-1 §4.1, static media uses the
+ *   configured default — see applyItemTiming)
  * @returns {Object} DP1 playlist item
  * @throws {Error} When token data is missing or source is a data URI
  * @example
  * const item = convertTokenToDP1ItemSingle(tokenInfo, 10);
  * // Returns: { title, source, duration, license, provenance, ... }
  */
-function convertTokenToDP1ItemSingle(tokenInfo, duration = 10) {
+function convertTokenToDP1ItemSingle(tokenInfo, duration) {
   const { token } = tokenInfo;
 
   if (!token) {
@@ -86,7 +156,6 @@ function convertTokenToDP1ItemSingle(tokenInfo, duration = 10) {
     id: itemId,
     title: token.name || `Token #${token.tokenId}`,
     source: sourceUrl,
-    duration: duration,
     license: 'token', // NFTs are token-gated by default
     created: new Date().toISOString(),
     provenance: {
@@ -117,7 +186,7 @@ function convertTokenToDP1ItemSingle(tokenInfo, duration = 10) {
     dp1Item.ref = token.image?.url || token.image;
   }
 
-  return dp1Item;
+  return applyItemTiming(dp1Item, { mimeType: token.image?.mimeType, sourceUrl }, duration);
 }
 
 /**
@@ -127,7 +196,7 @@ function convertTokenToDP1ItemSingle(tokenInfo, duration = 10) {
  * For collections, returns a map of token key to DP1 item.
  *
  * @param {Object|Array} tokenInfo - Token information (single object or map of tokens)
- * @param {number} duration - Display duration in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
  * @returns {Object} Map of token key to DP1 playlist item, or single item
  * @example
  * // Single token
@@ -136,7 +205,7 @@ function convertTokenToDP1ItemSingle(tokenInfo, duration = 10) {
  * // Multiple tokens
  * const items = convertTokenToDP1Item({ token1: info1, token2: info2 }, 10);
  */
-function convertTokenToDP1Item(tokenInfo, duration = 10) {
+function convertTokenToDP1Item(tokenInfo, duration) {
   // Handle array or map of tokens
   if (typeof tokenInfo === 'object' && !tokenInfo.token) {
     const results = {};
@@ -178,12 +247,12 @@ function convertTokenToDP1Item(tokenInfo, duration = 10) {
  * Excludes items with data URIs in their source field.
  *
  * @param {Array} tokensInfo - Array of token information
- * @param {number} duration - Display duration in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
  * @returns {Array} Array of DP1 playlist items
  * @example
  * const items = convertTokensToDP1Items(tokensInfoArray, 10);
  */
-function convertTokensToDP1Items(tokensInfo, duration = 10) {
+function convertTokensToDP1Items(tokensInfo, duration) {
   return tokensInfo
     .filter((info) => info.success && info.token)
     .map((info) => {
@@ -339,7 +408,10 @@ async function buildDP1Playlist(paramsOrItems, options = {}) {
         margin: 0,
       },
       license: 'token',
-      duration: 10,
+      // No defaults.duration: items that should be timed carry an explicit
+      // duration already, and a playlist-level default would make conformant
+      // players time-cut items that intentionally omit duration to play
+      // their natural length (DP-1 §4.1 end-of-stream advance).
     },
   };
 
@@ -410,10 +482,14 @@ function validateDP1Playlist(playlist) {
         errors.push(`Item ${index}: Field "source" must be a string (URI)`);
       }
 
-      if (item.duration === undefined || item.duration === null) {
-        errors.push(`Item ${index}: Missing required field "duration"`);
-      } else if (typeof item.duration !== 'number' || item.duration < 1) {
-        errors.push(`Item ${index}: Field "duration" must be a number >= 1`);
+      // Duration is OPTIONAL per the DP-1 v1.1.0 schema (PlaylistItem requires
+      // only `source`; duration has `minimum: 0`). Absent duration is meaningful:
+      // time-based sources advance at end-of-stream (§4.1). Do not tighten this
+      // back to required — it would reject spec-valid playlists.
+      if (item.duration !== undefined && item.duration !== null) {
+        if (typeof item.duration !== 'number' || item.duration < 0) {
+          errors.push(`Item ${index}: Field "duration" must be a number >= 0`);
+        }
       }
 
       if (!item.license) {
@@ -499,12 +575,13 @@ function detectMimeType(url) {
  * Build a single DP1 playlist item from a URL
  *
  * @param {string} url - Media URL
- * @param {number} duration - Duration per item in seconds
+ * @param {number} [duration] - Explicit display seconds; omit for auto timing
+ *   (video/audio URLs play their natural length per DP-1 §4.1)
  * @param {Object} [options] - Optional configuration
  * @param {string} [options.title] - Optional item title override
  * @returns {Object} DP1 playlist item
  */
-function buildUrlItem(url, duration = 10, options = {}) {
+function buildUrlItem(url, duration, options = {}) {
   const sourceUrl = String(url || '').trim();
   if (!sourceUrl) {
     throw new Error('URL is required to build a playlist item');
@@ -536,7 +613,6 @@ function buildUrlItem(url, duration = 10, options = {}) {
     id: itemId,
     title,
     source: sourceUrl,
-    duration: duration,
     license: 'open',
     created: new Date().toISOString(),
     provenance: {
@@ -550,7 +626,7 @@ function buildUrlItem(url, duration = 10, options = {}) {
     },
   };
 
-  return item;
+  return applyItemTiming(item, { sourceUrl }, duration);
 }
 
 module.exports = {
@@ -561,5 +637,7 @@ module.exports = {
   buildDP1Playlist,
   validateDP1Playlist,
   detectMimeType,
+  isTimeBasedMedia,
+  applyItemTiming,
   buildUrlItem,
 };

--- a/src/utilities/playlist-source.ts
+++ b/src/utilities/playlist-source.ts
@@ -131,13 +131,15 @@ export type PlaySource =
  * `loadedAsPlaylist` boolean dance.
  *
  * @param source - User-supplied path or URL
- * @param defaultDuration - Duration (seconds) for the synthesized media item
+ * @param defaultDuration - Explicit duration (seconds) for the synthesized
+ *   media item; omit for auto timing (video/audio URLs play their natural
+ *   length per DP-1 §4.1, static media uses the configured default)
  * @returns Resolved playlist + metadata describing how it was loaded
  * @throws Error When `source` is empty, or is a non-URL file path that cannot be loaded
  */
 export async function resolvePlaySource(
   source: string,
-  defaultDuration: number
+  defaultDuration?: number
 ): Promise<PlaySource> {
   const trimmed = source.trim();
   if (!trimmed) {

--- a/tests/playlist-item-timing.test.ts
+++ b/tests/playlist-item-timing.test.ts
@@ -1,0 +1,172 @@
+/**
+ * DP-1 §4.1 playback-timing conformance for item builders.
+ *
+ * `duration` is OPTIONAL in the DP-1 v1.1.0 schema (PlaylistItem requires only
+ * `source`). Absence is meaningful: a time-based source (video/audio) with
+ * `display.loop: false` and no duration MUST advance at end-of-stream — the
+ * media plays its natural length. These tests pin the auto-timing contract:
+ * omitted duration → video/audio items carry no duration and loop=false,
+ * static items fall back to the configured default, and an explicit duration
+ * always wins regardless of media type.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  applyItemTiming,
+  isTimeBasedMedia,
+  buildUrlItem,
+  convertTokenToDP1ItemSingle,
+  validateDP1Playlist,
+  buildDP1Playlist,
+} = require('../src/utilities/playlist-builder.js');
+const nftIndexer = require('../src/utilities/nft-indexer');
+
+/** Minimal token info in the standard format both converters consume. */
+function tokenInfo(overrides: { mimeType?: string; animationUrl?: string } = {}) {
+  return {
+    success: true,
+    token: {
+      chain: 'ethereum',
+      contractAddress: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+      tokenId: '1',
+      standard: 'erc721',
+      name: 'Chapter #1',
+      image: {
+        url: 'https://example.com/thumb.png',
+        mimeType: overrides.mimeType ?? 'image/png',
+        thumbnail: '',
+      },
+      animation_url: overrides.animationUrl,
+    },
+  };
+}
+
+describe('isTimeBasedMedia', () => {
+  test('detects video and audio by MIME type', () => {
+    assert.equal(isTimeBasedMedia('video/mp4', 'https://example.com/a'), true);
+    assert.equal(isTimeBasedMedia('audio/mpeg', 'https://example.com/a'), true);
+    assert.equal(isTimeBasedMedia('image/png', 'https://example.com/a.png'), false);
+  });
+
+  test('falls back to URL extension when MIME is missing or defaulted', () => {
+    assert.equal(isTimeBasedMedia(undefined, 'https://example.com/clip.mp4'), true);
+    // Upstream defaults missing mime_type to image/png; the extension must still win.
+    assert.equal(isTimeBasedMedia('image/png', 'https://example.com/clip.webm?x=1'), true);
+    assert.equal(isTimeBasedMedia(undefined, 'https://example.com/page.html'), false);
+  });
+});
+
+describe('applyItemTiming', () => {
+  test('explicit duration wins for any media type', () => {
+    const item: Record<string, unknown> = {};
+    applyItemTiming(item, { mimeType: 'video/mp4', sourceUrl: 'https://e.com/v.mp4' }, 25);
+    assert.equal(item.duration, 25);
+    assert.equal(item.display, undefined);
+  });
+
+  test('auto + video: no duration, display.loop=false (end-of-stream advance)', () => {
+    const item: Record<string, unknown> = { display: { scaling: 'fit' } };
+    applyItemTiming(item, { mimeType: 'video/mp4', sourceUrl: 'https://e.com/v.mp4' });
+    assert.equal('duration' in item, false);
+    assert.deepEqual(item.display, { scaling: 'fit', loop: false });
+  });
+
+  test('auto + static: configured default duration is stamped', () => {
+    const item: Record<string, unknown> = {};
+    applyItemTiming(item, { mimeType: 'image/png', sourceUrl: 'https://e.com/i.png' });
+    assert.equal(typeof item.duration, 'number');
+    assert.ok((item.duration as number) >= 1);
+  });
+});
+
+describe('item builders honor auto timing', () => {
+  test('buildUrlItem: video URL gets no duration and loop=false', () => {
+    const item = buildUrlItem('https://example.com/chapter-1.mp4');
+    assert.equal('duration' in item, false);
+    assert.equal(item.display.loop, false);
+  });
+
+  test('buildUrlItem: static URL keeps a numeric duration', () => {
+    const item = buildUrlItem('https://example.com/art.png');
+    assert.equal(typeof item.duration, 'number');
+    assert.equal(item.display.loop, undefined);
+  });
+
+  test('buildUrlItem: explicit duration is stamped as-is on video', () => {
+    const item = buildUrlItem('https://example.com/chapter-1.mp4', 30);
+    assert.equal(item.duration, 30);
+  });
+
+  test('convertTokenToDP1ItemSingle: video token (indexer MIME) → natural length', () => {
+    const item = convertTokenToDP1ItemSingle(
+      tokenInfo({ mimeType: 'video/mp4', animationUrl: 'https://example.com/chapter-1.mp4' })
+    );
+    assert.equal('duration' in item, false);
+    assert.equal(item.display.loop, false);
+  });
+
+  test('convertTokenToDP1ItemSingle: static token keeps default duration', () => {
+    const item = convertTokenToDP1ItemSingle(tokenInfo());
+    assert.equal(typeof item.duration, 'number');
+    assert.equal(item.display.loop, undefined);
+  });
+
+  test('nft-indexer convertToDP1Item: video token → natural length, explicit wins', () => {
+    const video = tokenInfo({
+      mimeType: 'video/mp4',
+      animationUrl: 'https://example.com/chapter-1.mp4',
+    });
+    const auto = nftIndexer.convertToDP1Item(video);
+    assert.equal(auto.success, true);
+    assert.equal('duration' in auto.item, false);
+    assert.equal(auto.item.display.loop, false);
+
+    const explicit = nftIndexer.convertToDP1Item(video, 30);
+    assert.equal(explicit.item.duration, 30);
+  });
+});
+
+describe('playlist-level conformance', () => {
+  test('validateDP1Playlist accepts items without duration (spec-optional)', () => {
+    const result = validateDP1Playlist({
+      dpVersion: '1.1.0',
+      title: 'No-duration video',
+      items: [
+        {
+          source: 'https://example.com/chapter-1.mp4',
+          license: 'open',
+          display: { loop: false },
+        },
+      ],
+    });
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.valid, true);
+  });
+
+  test('validateDP1Playlist rejects negative duration but allows 0', () => {
+    const base = {
+      dpVersion: '1.1.0',
+      title: 'Durations',
+      items: [{ source: 'https://example.com/a.png', license: 'open', duration: -1 }],
+    };
+    assert.equal(validateDP1Playlist(base).valid, false);
+    base.items[0].duration = 0;
+    assert.equal(validateDP1Playlist(base).valid, true);
+  });
+
+  test('buildDP1Playlist emits no defaults.duration (would time-cut no-duration items)', async () => {
+    const playlist = await buildDP1Playlist({
+      items: [buildUrlItem('https://example.com/chapter-1.mp4')],
+      title: 'Natural length',
+      slug: 'natural-length',
+      deterministicMode: true,
+      fixedTimestamp: '2026-06-01T12:00:00.000Z',
+      fixedId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+    assert.equal('duration' in playlist.defaults, false);
+  });
+});


### PR DESCRIPTION
## Problem

ff-cli stamped a fixed `duration` (default 10s) on every playlist item. For video and audio works this silently truncates or pads playback: a 30-second piece gets cut at 10s, or loops to fill an arbitrary window.

The DP-1 v1.1.0 schema makes `duration` **optional** (`PlaylistItem` requires only `source`), and §4.1 defines what its absence means: a time-based source with `display.loop: false` MUST advance at end-of-stream — i.e., the media plays its natural length. ff-cli could neither emit that form nor validate it (`validateDP1Playlist` required `duration >= 1`, stricter than the spec).

## Change

When no explicit duration is requested:

- **video/audio items** are emitted with no `duration` and `display.loop: false` → the player advances at end-of-stream. Detection uses the indexer `mime_type` with a URL-extension fallback (`detectMimeType`).
- **static/code items** keep the configured `defaultDuration` (they have no intrinsic runtime).

An explicit duration always wins, on every path: `build` params (`playlistSettings.durationPerItem`), `chat`, `find`, `play`.

Supporting fixes:

- `validateDP1Playlist`: `duration` is optional; rejects negatives only (spec: `minimum: 0`)
- `buildDP1Playlist`: no longer emits `defaults.duration`, which would let conformant players time-cut items that intentionally omit duration
- feed items keep their own timing unless an override is requested
- intent parser and orchestrator no longer fabricate a duration when the user gives none

The single timing decision lives in `applyItemTiming` (`src/utilities/playlist-builder.js`); both item converters and `buildUrlItem` route through it.

## Testing

- 353 tests pass (`npm run verify` clean), including 14 new tests in `tests/playlist-item-timing.test.ts` pinning the auto-timing contract
- Signed no-duration playlist passes `ff-cli validate` and dp1-js signature verification
- Verified on an FF1 device: a 30.4s mp4 sent via `ff-cli play <url>` plays to its natural end before the playlist advances (previously cut at 10s); an explicit `duration: 7` on the same clip cuts at 7s as expected