### PR TITLE
feat: support OpenSea /collection/{slug} URLs in find

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,6 +148,7 @@ Notes:
   - Options: `-d, --device <name>`, `--skip-verify` (skip signature verification; not recommended)
 - `find <input>` – Resolve a marketplace URL, raw `chain:contract:tokenId`, or wallet address into a playable DP-1 playlist
   - Sources: Art Blocks, Objkt, fxhash, OpenSea, SuperRare, Feral File, Neort, Verse, raw on-chain coordinates, and wallet addresses
+  - OpenSea forms: `/assets/ethereum/{contract}/{tokenId}`, `/item/ethereum/{contract}/{tokenId}`, and `/collection/{slug}` (Ethereum collections; the slug is resolved from the public collection page, no API key needed)
   - Verse forms: `/items/ethereum/{contract}/{tokenId}` and `/series/{slug}`
   - Options: `-o, --output <path>`, `-l, --limit <n>`, `-p, --play`, `-d, --device <name>`, `--publish`, `-s, --server <index>`, `-y, --yes`, `--skip-verify`
 - `publish <file>` – Publish a playlist to a feed server (runs `verify` before upload and rejects unsigned or broken playlists)

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -8,6 +8,7 @@ import type { TokenCoords } from '../utilities/marketplace-url';
 import { resolveFeralFileToken } from '../utilities/ff-marketplace';
 import { resolveObjktAlias } from '../utilities/objkt-marketplace';
 import { resolveArtBlocksCollection } from '../utilities/ab-marketplace';
+import { resolveOpenSeaCollection } from '../utilities/opensea-marketplace';
 import { resolveFxhashIteration, resolveFxhashProject } from '../utilities/fxhash-marketplace';
 import { resolveNeortArt } from '../utilities/neort-marketplace';
 import type { NeortArt } from '../utilities/neort-marketplace';
@@ -227,6 +228,10 @@ async function resolveTarget(
   }
   if (parsed.kind === 'ab-collection') {
     const coords = await resolveArtBlocksCollection(parsed.slug);
+    return resolveCoords(coords);
+  }
+  if (parsed.kind === 'os-collection') {
+    const coords = await resolveOpenSeaCollection(parsed.slug);
     return resolveCoords(coords);
   }
   if (parsed.kind === 'fxhash-iteration') {

--- a/src/utilities/marketplace-url.ts
+++ b/src/utilities/marketplace-url.ts
@@ -42,6 +42,7 @@ export type ParsedFindInput =
   | { kind: 'ff-url'; urlKind: FeralFileUrlKind; identifier: string }
   | { kind: 'objkt-alias'; alias: string; tokenId: string }
   | { kind: 'ab-collection'; slug: string }
+  | { kind: 'os-collection'; slug: string }
   | { kind: 'fxhash-iteration'; slug: string }
   | { kind: 'fxhash-project'; slug: string }
   | { kind: 'neort-art'; id: string }
@@ -281,7 +282,7 @@ export function parseFxhash(url: URL): ParsedFindInput {
  * OpenSea URL forms:
  *   opensea.io/assets/{chain}/{contract}/{tokenId}
  *   opensea.io/item/{chain}/{contract}/{tokenId}    — newer naming
- *   opensea.io/collection/{slug}                    — series slug (not yet)
+ *   opensea.io/collection/{slug}                    — collection slug (series)
  *
  * Only `ethereum` is in scope; other chains (matic, base, solana, etc.)
  * fall outside the FF indexer's coverage. Token URLs resolve end-to-end only
@@ -308,12 +309,16 @@ export function parseOpenSea(url: URL): ParsedFindInput {
       coords: { chain: 'ethereum', contract: tokenMatch[2].toLowerCase(), tokenId: tokenMatch[3] },
     };
   }
+  const collectionMatch = /^\/collection\/([a-z0-9][a-z0-9-]*)\/?$/.exec(url.pathname);
+  if (collectionMatch) {
+    return { kind: 'os-collection', slug: collectionMatch[1] };
+  }
   if (url.pathname.startsWith('/collection/')) {
     return {
       kind: 'unsupported',
       reason:
-        'OpenSea `/collection/{slug}` URLs are not yet supported in v1. Paste a specific token ' +
-        'URL (opensea.io/assets/ethereum/{contract}/{tokenId}) or use `ethereum:{contract}:{tokenId}`.',
+        `OpenSea collection URL not recognized: ${url.pathname}. ` +
+        'Expected opensea.io/collection/{slug} with no extra path segments.',
     };
   }
   return {

--- a/src/utilities/opensea-marketplace.ts
+++ b/src/utilities/opensea-marketplace.ts
@@ -1,0 +1,107 @@
+/**
+ * OpenSea marketplace resolver.
+ *
+ * OpenSea collection URLs (`opensea.io/collection/{slug}`) point to a series,
+ * not a token. OpenSea's REST API requires an API key, so this resolver reads
+ * the public collection page instead: the server-rendered HTML embeds the
+ * first page of collection items as relay-style JSON where each item carries
+ * `"chain":{"identifier":...},"contractAddress":"0x...","tokenId":"..."`
+ * adjacently. One extracted (contract, tokenId) pair is enough — the standard
+ * Raster reverse-lookup then enumerates the rest of the series like any other
+ * marketplace.
+ *
+ * Extraction invariants (what must not change):
+ * - Match only the adjacent `contractAddress` + `tokenId` pattern. The page
+ *   also embeds payment-token contracts (WETH etc.) in other JSON shapes that
+ *   never carry an adjacent tokenId, so adjacency is the noise filter.
+ * - The most frequent contract among matches wins (collection items dominate
+ *   any stray adjacency), and its lowest tokenId is the deterministic seed.
+ * - tokenIds are compared as BigInt: ERC-721 ids can exceed Number range.
+ *
+ * Trade-off: scraping page HTML is less stable than a documented API, but the
+ * alternative (requiring every user to provision an OpenSea API key) defeats
+ * the paste-a-URL UX. Errors below name the fallback (`/item/` token URL) so
+ * a layout change degrades to a one-step workaround, not a dead end.
+ */
+
+import * as logger from '../logger';
+import type { TokenCoords } from './marketplace-url';
+import { USER_AGENT } from './user-agent';
+
+/**
+ * One embedded collection item: chain identifier, contract, tokenId. The
+ * `[^{}]*` keeps the chain object match from swallowing unrelated JSON when
+ * OpenSea reorders fields inside `chain`.
+ */
+const ITEM_PATTERN =
+  /"chain":\{"identifier":"([a-z0-9_-]+)"[^{}]*\},"contractAddress":"(0x[a-fA-F0-9]{40})","tokenId":"(\d+)"/g;
+
+const FALLBACK_HINT =
+  'Paste a specific token URL (opensea.io/item/ethereum/{contract}/{tokenId}) ' +
+  'or use `ethereum:{contract}:{tokenId}`.';
+
+/**
+ * Resolve an OpenSea collection slug to its contract address + the lowest
+ * tokenId visible on the collection page (a representative seed for the
+ * Raster series lookup).
+ *
+ * @throws When the page cannot be fetched, embeds no recognizable items
+ *   (layout change or empty collection), or the collection is not on
+ *   Ethereum mainnet (outside FF indexer coverage).
+ */
+export async function resolveOpenSeaCollection(slug: string): Promise<TokenCoords> {
+  logger.debug(`[OpenSea] Resolving collection slug "${slug}"`);
+  const response = await fetch(`https://opensea.io/collection/${encodeURIComponent(slug)}`, {
+    headers: { 'User-Agent': USER_AGENT, Accept: 'text/html' },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `OpenSea collection page returned ${response.status} ${response.statusText}. ` + FALLBACK_HINT
+    );
+  }
+  const html = await response.text();
+
+  // Tally (contract → tokenIds) per chain so the dominant-contract rule and
+  // the ethereum-only guard can both give precise errors.
+  const byContract = new Map<string, { chain: string; tokenIds: bigint[] }>();
+  for (const match of html.matchAll(ITEM_PATTERN)) {
+    const [, chain, contract, tokenId] = match;
+    const key = contract.toLowerCase();
+    const entry = byContract.get(key) ?? { chain, tokenIds: [] };
+    entry.tokenIds.push(BigInt(tokenId));
+    byContract.set(key, entry);
+  }
+
+  if (byContract.size === 0) {
+    throw new Error(
+      `OpenSea: no items found on the collection page for "${slug}". ` +
+        'The collection may be empty, or the page layout changed. ' +
+        FALLBACK_HINT
+    );
+  }
+
+  let best: { contract: string; chain: string; tokenIds: bigint[] } | null = null;
+  for (const [contract, entry] of byContract) {
+    if (!best || entry.tokenIds.length > best.tokenIds.length) {
+      best = { contract, ...entry };
+    }
+  }
+  // byContract.size > 0 guarantees best is set; the check keeps TS honest.
+  if (!best) {
+    throw new Error(`OpenSea: no items found for "${slug}". ${FALLBACK_HINT}`);
+  }
+
+  if (best.chain !== 'ethereum') {
+    throw new Error(
+      `OpenSea collection "${slug}" is on ${best.chain} — ff-cli covers Ethereum and ` +
+        'Tezos mainnet only. Paste an Ethereum-chain source instead.'
+    );
+  }
+
+  const seed = best.tokenIds.reduce((min, id) => (id < min ? id : min));
+  logger.debug(
+    `[OpenSea] Resolved "${slug}" → ${best.contract} (seed tokenId ${seed}, ` +
+      `${best.tokenIds.length} items sampled)`
+  );
+  return { chain: 'ethereum', contract: best.contract, tokenId: seed.toString() };
+}

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -199,9 +199,9 @@ describe('parseFindInput', () => {
     assert.ok(r.reason.includes('matic'));
   });
 
-  test('OpenSea collection URL → unsupported with hint', () => {
+  test('OpenSea collection URL → os-collection kind', () => {
     const r = parseFindInput('https://opensea.io/collection/azuki');
-    assert.equal(r?.kind, 'unsupported');
+    assert.deepEqual(r, { kind: 'os-collection', slug: 'azuki' });
   });
 
   test('SuperRare /artwork/eth/{contract}/{tokenId} → token kind, source superrare', () => {

--- a/tests/opensea-collection.test.ts
+++ b/tests/opensea-collection.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the OpenSea collection-slug resolver behind `ff-cli find`.
+ *
+ * `resolveOpenSeaCollection` scrapes the public collection page for embedded
+ * relay-style item JSON. These tests stub `global.fetch` with canned HTML so
+ * the extraction invariants are pinned without hitting opensea.io:
+ * adjacency-based noise filtering, dominant-contract selection, lowest-seed
+ * tokenId, BigInt-safe id comparison, the ethereum-only guard, and error
+ * paths (HTTP failure, no items).
+ *
+ * Pattern matches `tests/find-resolvers.test.ts`: save global.fetch, assign
+ * a mock, restore in finally.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { resolveOpenSeaCollection } from '../src/utilities/opensea-marketplace';
+import { parseFindInput } from '../src/utilities/marketplace-url';
+
+type FetchFn = typeof global.fetch;
+
+function htmlResponse(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { 'Content-Type': 'text/html' } });
+}
+
+async function withMockedFetch<T>(mock: FetchFn, run: () => Promise<T>): Promise<T> {
+  const original = global.fetch;
+  global.fetch = mock;
+  try {
+    return await run();
+  } finally {
+    global.fetch = original;
+  }
+}
+
+/** One embedded collection item in the shape OpenSea's page renders. */
+function item(chain: string, contract: string, tokenId: string): string {
+  return (
+    `{"id":"x","chain":{"identifier":"${chain}","__typename":"Chain","arch":"EVM",` +
+    `"name":"Chain"},"contractAddress":"${contract}","tokenId":"${tokenId}","isFungible":false}`
+  );
+}
+
+const COLLECTION_CONTRACT = '0xe293247b582759495d0320ee8a87f598cc052c5b';
+const STRAY_CONTRACT = '0x1111111111111111111111111111111111111111';
+
+/** Payment-token noise: contractAddress with no adjacent tokenId. */
+const WETH_NOISE =
+  '{"symbol":"WETH","contractAddress":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","decimals":18}';
+
+describe('resolveOpenSeaCollection', () => {
+  test('extracts dominant contract and lowest tokenId, ignoring payment-token noise', async () => {
+    const html =
+      '<html><script>' +
+      WETH_NOISE +
+      item('ethereum', COLLECTION_CONTRACT, '97') +
+      item('ethereum', COLLECTION_CONTRACT, '15') +
+      item('ethereum', COLLECTION_CONTRACT, '40') +
+      item('ethereum', STRAY_CONTRACT, '7') + // stray adjacency loses on frequency
+      '</script></html>';
+
+    const coords = await withMockedFetch((async () => htmlResponse(html)) as FetchFn, () =>
+      resolveOpenSeaCollection('a-eye-after-johannes-itten')
+    );
+    assert.deepEqual(coords, {
+      chain: 'ethereum',
+      contract: COLLECTION_CONTRACT,
+      tokenId: '15',
+    });
+  });
+
+  test('compares tokenIds as BigInt (ids beyond Number range)', async () => {
+    const big = '106531167402379141148776360336529888293057364703212462867524098456103606550529';
+    const html =
+      item('ethereum', COLLECTION_CONTRACT, big) + item('ethereum', COLLECTION_CONTRACT, '9');
+    const coords = await withMockedFetch((async () => htmlResponse(html)) as FetchFn, () =>
+      resolveOpenSeaCollection('big-ids')
+    );
+    assert.equal(coords.tokenId, '9');
+  });
+
+  test('rejects non-ethereum collections with a chain-specific message', async () => {
+    const html = item('matic', STRAY_CONTRACT, '1') + item('matic', STRAY_CONTRACT, '2');
+    await assert.rejects(
+      withMockedFetch((async () => htmlResponse(html)) as FetchFn, () =>
+        resolveOpenSeaCollection('polygon-collection')
+      ),
+      /on matic/
+    );
+  });
+
+  test('errors with fallback hint when the page embeds no items', async () => {
+    await assert.rejects(
+      withMockedFetch((async () => htmlResponse('<html>js shell only</html>')) as FetchFn, () =>
+        resolveOpenSeaCollection('empty-or-changed')
+      ),
+      /no items found.*opensea\.io\/item\/ethereum/s
+    );
+  });
+
+  test('errors with status code on HTTP failure', async () => {
+    await assert.rejects(
+      withMockedFetch((async () => htmlResponse('blocked', 403)) as FetchFn, () =>
+        resolveOpenSeaCollection('blocked')
+      ),
+      /returned 403/
+    );
+  });
+});
+
+describe('parseFindInput: OpenSea collection URLs', () => {
+  test('opensea.io/collection/{slug} parses to os-collection', () => {
+    const r = parseFindInput('https://opensea.io/collection/a-eye-after-johannes-itten');
+    assert.deepEqual(r, { kind: 'os-collection', slug: 'a-eye-after-johannes-itten' });
+  });
+
+  test('trailing slash is accepted', () => {
+    const r = parseFindInput('https://opensea.io/collection/some-slug/');
+    assert.deepEqual(r, { kind: 'os-collection', slug: 'some-slug' });
+  });
+
+  test('extra path segments stay unsupported with a clear reason', () => {
+    const r = parseFindInput('https://opensea.io/collection/some-slug/activity');
+    assert.equal(r?.kind, 'unsupported');
+  });
+});


### PR DESCRIPTION
## Problem

OpenSea collection URLs (`opensea.io/collection/{slug}`) are the link collectors most often share, but `find` only accepted token URLs and rejected collection slugs with a "not yet supported in v1" error. OpenSea's REST API that maps a slug to its contract requires an API key, which defeats the paste-a-URL UX.

## Change

Resolve the slug from the public collection page instead — no API key needed. The server-rendered HTML embeds the first page of collection items as relay-style JSON where `chain`, `contractAddress`, and `tokenId` appear adjacently. The resolver (`src/utilities/opensea-marketplace.ts`, mirroring the Art Blocks collection-resolver shape):

- matches only the adjacent `contractAddress` + `tokenId` pattern, which filters payment-token noise (WETH etc. never carry an adjacent tokenId)
- picks the most frequent contract among matches (collection items dominate any stray adjacency) and seeds the standard Raster series lookup with its lowest tokenId (BigInt-compared — ERC-721 ids can exceed Number range)
- rejects non-Ethereum collections with a chain-specific message, and degrades to a clear "paste a token URL" hint on HTTP failure or layout change

`parseOpenSea` now emits an `os-collection` kind wired into `find`'s resolver chain. Uses the standard `ff-cli/<version>` User-Agent (verified OpenSea serves the embedded JSON to it).

## Testing

- 347 tests pass; new suite `tests/opensea-collection.test.ts` pins the extraction invariants (noise filtering, dominant-contract rule, BigInt seed, chain guard, error paths) against canned HTML
- Verified live: `ff-cli find https://opensea.io/collection/a-eye-after-johannes-itten` resolves slug → contract → playlist end to end