### PR TITLE
feat: migrate Raster integration to public GraphQL API (api.raster.art)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -116,6 +116,19 @@ Environment variable alternative:
 FEED_BASE_URLS=https://dp1-feed-operator-api-prod.autonomy-system.workers.dev/api/v1,https://dp1-feed-operator-api-prod.autonomy-system.workers.dev/api/v1
 ```
 
+## find (Raster API)
+
+`ff-cli find` resolves tokens, series, and artist addresses through Raster's public GraphQL API ([docs.api.raster.art](https://docs.api.raster.art/)). No configuration is required; two environment variables adjust the integration:
+
+```env
+# API key sent as the x-api-key header. The API currently answers without
+# one, but Raster's docs declare a key required — set this once enforced.
+RASTER_API_KEY=rk_your_key_here
+
+# Override the GraphQL endpoint (default: https://api.raster.art/graphql).
+RASTER_API_URL=https://api.raster.art/graphql
+```
+
 ## ff1Devices
 
 Configure devices you want to play content on.

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -15,7 +15,6 @@ import type { NeortArt } from '../utilities/neort-marketplace';
 import { resolveVerseSeries } from '../utilities/verse-marketplace';
 import {
   resolveTokenToArtwork,
-  getArtworkSummary,
   listArtworkTokens,
   listArtistArtworks,
   resolveAddressToArtist,
@@ -126,31 +125,50 @@ export const findCommand = new Command('find')
       console.log();
 
       const userLimit = parseLimitOption(options.limit);
-      const seriesTotal = target.kind === 'series' ? target.summary.tokenCount : 1;
       // Implicit cap: no --limit + series > 1024 → cap to DP-1 max with a
       // clear warning. Explicit `--limit > 1024` was already rejected by
       // parseLimitOption, so reaching here means either capped-by-default or
       // the user picked a value within spec.
       const limit = Math.min(userLimit, DP1_MAX_ITEMS);
-      if (userLimit === Number.POSITIVE_INFINITY && seriesTotal > DP1_MAX_ITEMS) {
+
+      // Raster's GraphQL API exposes no series token counts, so enumerate
+      // tokens first (up to the effective limit) and confirm with the real
+      // number afterward. `hasMore` means the series continues past `limit`.
+      let tokens: TokenCoords[];
+      let seriesHasMore = false;
+      if (target.kind === 'series') {
+        const fetched = await fetchTokens(target.summary, limit);
+        tokens = fetched.tokens;
+        seriesHasMore = fetched.hasMore;
+      } else {
+        tokens = [target.coords];
+      }
+
+      if (tokens.length === 0) {
+        console.error(
+          chalk.red('Series has no tokens on supported chains (Ethereum + Tezos mainnet).')
+        );
+        process.exit(1);
+      }
+
+      if (userLimit === Number.POSITIVE_INFINITY && seriesHasMore) {
         console.log(
           chalk.yellow(
-            `Series has ${seriesTotal} tokens; DP-1 caps playlists at ${DP1_MAX_ITEMS}. ` +
+            `Series has more than ${DP1_MAX_ITEMS} tokens; DP-1 caps playlists at ${DP1_MAX_ITEMS}. ` +
               `Building with the first ${DP1_MAX_ITEMS} — pass \`--limit N\` (≤ ${DP1_MAX_ITEMS}) for fewer.`
           )
         );
         console.log();
       }
-      const willInclude = Math.min(seriesTotal, limit);
+
       const shouldBuild =
-        !!options.yes || !!options.output || (await confirmMakePlaylist(willInclude, seriesTotal));
+        !!options.yes ||
+        !!options.output ||
+        (await confirmMakePlaylist(tokens.length, seriesHasMore));
       if (!shouldBuild) {
         console.log(chalk.dim('Cancelled.'));
         return;
       }
-
-      const tokens =
-        target.kind === 'series' ? await fetchTokens(target.summary, limit) : [target.coords];
       console.log(
         chalk.dim(
           `Indexing ${tokens.length} token${tokens.length === 1 ? '' : 's'} via FF indexer...`
@@ -248,35 +266,36 @@ async function resolveTarget(
     return resolveCoords(coords);
   }
   if (parsed.kind === 'address') {
-    const artistId = await resolveAddressToArtist(parsed.address);
-    if (artistId === null) {
+    const artist = await resolveAddressToArtist(parsed.address);
+    if (artist === null) {
       throw new Error(
         `No artist found on Raster for address ${parsed.address}. ` +
           'Raster indexes artists by their on-chain addresses; this address may not yet be claimed.'
       );
     }
-    const catalog = await listArtistArtworks(artistId);
+    const catalog = await listArtistArtworks(artist.id);
     if (catalog.length === 0) {
       throw new Error('Artist has no artworks indexed on Raster.');
     }
     const picked = await pickFromCatalog(catalog, skipPrompt);
-    const summary = await getArtworkSummary(picked.artworkId);
-    return { kind: 'series', summary };
+    return {
+      kind: 'series',
+      summary: { artworkId: picked.artworkId, title: picked.title, artists: [artist] },
+    };
   }
   // `unsupported` is handled upstream; this branch keeps the type narrowing honest.
   throw new Error(`Unsupported parse result: ${parsed.kind}`);
 }
 
 /**
- * Resolve on-chain coords to a target. If Raster doesn't index this token
- * (404), fall back to single-token mode so we still build something playable.
+ * Resolve on-chain coords to a target. If Raster doesn't index this token,
+ * fall back to single-token mode so we still build something playable.
  */
 async function resolveCoords(coords: TokenCoords): Promise<ResolvedTarget> {
-  const lookup = await resolveTokenToArtwork(coords.chain, coords.contract, coords.tokenId);
-  if (lookup === null) {
+  const summary = await resolveTokenToArtwork(coords.chain, coords.contract, coords.tokenId);
+  if (summary === null) {
     return { kind: 'single', coords };
   }
-  const summary = await getArtworkSummary(lookup.artworkId);
   return { kind: 'series', summary };
 }
 
@@ -312,12 +331,21 @@ export function parseLimitOption(limitStr: string | undefined): number {
   return n;
 }
 
-async function fetchTokens(summary: RasterArtworkSummary, limit: number): Promise<TokenCoords[]> {
+/**
+ * Enumerate series tokens from Raster up to `limit`. `hasMore` reports
+ * whether the series continues past what was collected — the API exposes
+ * no total counts, so this is all the size information the flow gets.
+ */
+async function fetchTokens(
+  summary: RasterArtworkSummary,
+  limit: number
+): Promise<{ tokens: TokenCoords[]; hasMore: boolean }> {
   const collected: TokenCoords[] = [];
-  let cursor: number | undefined;
+  let cursor: string | undefined;
   let skipped = 0;
+  let hasMore = false;
 
-  while (collected.length < limit) {
+  for (;;) {
     const page = await listArtworkTokens(summary.artworkId, {
       cursor,
       pageSize: RASTER_PAGE_SIZE,
@@ -325,6 +353,7 @@ async function fetchTokens(summary: RasterArtworkSummary, limit: number): Promis
     skipped += page.skippedUnsupported;
     for (const t of page.tokens) {
       if (collected.length >= limit) {
+        hasMore = true;
         break;
       }
       collected.push({
@@ -333,7 +362,11 @@ async function fetchTokens(summary: RasterArtworkSummary, limit: number): Promis
         tokenId: t.tokenId,
       });
     }
-    if (page.nextCursor === null) {
+    if (hasMore || page.nextCursor === null) {
+      break;
+    }
+    if (collected.length >= limit) {
+      hasMore = true;
       break;
     }
     cursor = page.nextCursor;
@@ -347,7 +380,7 @@ async function fetchTokens(summary: RasterArtworkSummary, limit: number): Promis
     );
   }
 
-  return collected;
+  return { tokens: collected, hasMore };
 }
 
 async function pickFromCatalog(
@@ -359,8 +392,7 @@ async function pickFromCatalog(
   }
   console.log(chalk.cyan(`Found ${catalog.length} artworks for this artist:`));
   catalog.forEach((row, i) => {
-    const count = `${row.tokenCount} token${row.tokenCount === 1 ? '' : 's'}`;
-    console.log(chalk.dim(`  ${i}: ${row.title} (${count})`));
+    console.log(chalk.dim(`  ${i}: ${row.title}`));
   });
   console.log();
   const prompt = createPrompt();
@@ -376,9 +408,9 @@ async function pickFromCatalog(
   return catalog[index];
 }
 
-async function confirmMakePlaylist(count: number, total: number): Promise<boolean> {
-  const noun = total === 1 ? 'token' : 'tokens';
-  const label = count < total ? `${count} of ${total} ${noun}` : `${count} ${noun}`;
+async function confirmMakePlaylist(count: number, hasMore: boolean): Promise<boolean> {
+  const noun = count === 1 ? 'token' : 'tokens';
+  const label = hasMore ? `the first ${count} ${noun}` : `${count} ${noun}`;
   const prompt = createPrompt();
   const yes = await promptYesNo(prompt.ask, `Build playlist with ${label}?`, true);
   prompt.close();
@@ -593,7 +625,7 @@ async function runNeortFind(id: string, options: FindOptions): Promise<void> {
   );
   console.log();
 
-  const shouldBuild = !!options.yes || !!options.output || (await confirmMakePlaylist(1, 1));
+  const shouldBuild = !!options.yes || !!options.output || (await confirmMakePlaylist(1, false));
   if (!shouldBuild) {
     console.log(chalk.dim('Cancelled.'));
     return;

--- a/src/utilities/raster-client.ts
+++ b/src/utilities/raster-client.ts
@@ -26,7 +26,7 @@
 import * as logger from '../logger';
 import { USER_AGENT } from './user-agent';
 
-const RASTER_GRAPHQL_URL = process.env.RASTER_API_URL ?? 'https://api.raster.art/graphql';
+const DEFAULT_RASTER_GRAPHQL_URL = 'https://api.raster.art/graphql';
 
 // CAIP-2 chain IDs for the chains the FF indexer supports.
 // Tezos mainnet's CAIP form uses the genesis block hash (NetXdQprcVkpaWU),
@@ -62,7 +62,6 @@ export interface RasterArtworkRow {
 }
 
 export interface RasterTokenCoords {
-  caipChain: string;
   chain: IndexerChain;
   contractAddress: string;
   tokenId: string;
@@ -86,7 +85,8 @@ function caipToIndexerChain(caip: string): IndexerChain | null {
  * callers check their own field for null.
  */
 async function rasterQuery<T>(query: string, variables: Record<string, unknown>): Promise<T> {
-  logger.debug(`[Raster] POST ${RASTER_GRAPHQL_URL} ${JSON.stringify(variables)}`);
+  const endpoint = process.env.RASTER_API_URL ?? DEFAULT_RASTER_GRAPHQL_URL;
+  logger.debug(`[Raster] POST ${endpoint} ${JSON.stringify(variables)}`);
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'User-Agent': USER_AGENT,
@@ -95,7 +95,7 @@ async function rasterQuery<T>(query: string, variables: Record<string, unknown>)
   if (apiKey) {
     headers['x-api-key'] = apiKey;
   }
-  const response = await fetch(RASTER_GRAPHQL_URL, {
+  const response = await fetch(endpoint, {
     method: 'POST',
     headers,
     body: JSON.stringify({ query, variables }),
@@ -241,7 +241,6 @@ export async function listArtworkTokens(
       continue;
     }
     tokens.push({
-      caipChain: raw.chainId,
       chain,
       contractAddress: raw.contractAddress,
       tokenId: raw.tokenId,

--- a/src/utilities/raster-client.ts
+++ b/src/utilities/raster-client.ts
@@ -1,8 +1,8 @@
 /**
- * Raster API client (kit.raster.art)
+ * Raster API client (api.raster.art — public GraphQL API).
  *
- * Resolves on-chain coordinates and artist addresses into Raster `artwork_id`
- * (series) and `artist_id` (catalog) — the inputs the `ff-cli find` flow needs
+ * Resolves on-chain coordinates and artist addresses into Raster artworks
+ * (series) and artists (catalog) — the inputs the `ff-cli find` flow needs
  * before handing tokens to the FF GraphQL indexer for DP-1 conversion.
  *
  * This module is pure data: it does not construct DP-1 items, send anything
@@ -13,48 +13,52 @@
  * mainnet. Token lists are filtered here at the CAIP level and a
  * `skippedUnsupported` count is surfaced so callers can warn-skip without
  * walking every row themselves.
+ *
+ * API notes (v0.1.0, https://docs.api.raster.art/):
+ *  - Auth: `x-api-key` header, sent when RASTER_API_KEY is set in the
+ *    environment. The endpoint currently answers without a key; the docs
+ *    declare one required, so the hook is wired in ahead of enforcement.
+ *  - Not-found is a `null` query field, not an HTTP 404.
+ *  - Connections expose no total counts — callers learn series size by
+ *    paginating, so the find flow fetches before it prompts.
  */
 
 import * as logger from '../logger';
 import { USER_AGENT } from './user-agent';
 
-const RASTER_BASE_URL = 'https://kit.raster.art';
+const RASTER_GRAPHQL_URL = process.env.RASTER_API_URL ?? 'https://api.raster.art/graphql';
 
 // CAIP-2 chain IDs for the chains the FF indexer supports.
 // Tezos mainnet's CAIP form uses the genesis block hash (NetXdQprcVkpaWU),
 // not the human-readable "tezos:mainnet" — Raster returns the hash form on
-// token rows and rejects "tezos:mainnet" with HTTP 400.
+// token rows and resolves nothing for "tezos:mainnet".
 const CAIP_TO_INDEXER_CHAIN: Record<string, 'ethereum' | 'tezos'> = {
   'eip155:1': 'ethereum',
   'tezos:NetXdQprcVkpaWU': 'tezos',
 };
 
+const INDEXER_CHAIN_TO_CAIP: Record<IndexerChain, string> = {
+  ethereum: 'eip155:1',
+  tezos: 'tezos:NetXdQprcVkpaWU',
+};
+
 export type IndexerChain = 'ethereum' | 'tezos';
 
 export interface RasterArtist {
-  id: number;
+  id: string;
   name: string;
   slug: string | null;
 }
 
 export interface RasterArtworkSummary {
-  artworkId: number;
+  artworkId: string;
   title: string;
   artists: RasterArtist[];
-  tokenCount: number;
-  editionSize: number;
-  isEdition: boolean;
-  hasOneOfOneTokens: boolean;
-  platforms: Array<{ id: string; label: string }>;
-  contractAddresses: string[];
 }
 
 export interface RasterArtworkRow {
-  artworkId: number;
+  artworkId: string;
   title: string;
-  tokenCount: number;
-  isEdition: boolean;
-  mintDate: string | null;
 }
 
 export interface RasterTokenCoords {
@@ -66,14 +70,8 @@ export interface RasterTokenCoords {
 
 export interface PaginatedTokens {
   tokens: RasterTokenCoords[];
-  totalCount: number;
-  nextCursor: number | null;
+  nextCursor: string | null;
   skippedUnsupported: number;
-}
-
-function stripContractChainPrefix(raw: string): string {
-  const slash = raw.indexOf('/');
-  return slash >= 0 ? raw.slice(slash + 1) : raw;
 }
 
 function caipToIndexerChain(caip: string): IndexerChain | null {
@@ -81,176 +79,118 @@ function caipToIndexerChain(caip: string): IndexerChain | null {
 }
 
 /**
- * Thrown when Raster returns 404 for a requested path. Used as a soft signal
- * by callers that have a fallback path (e.g. `find` falls back to a
- * single-token playlist when Raster doesn't index the artwork).
+ * POST one GraphQL operation to Raster and return `data`.
+ *
+ * Throws on HTTP errors and on GraphQL `errors` entries. "Not found" never
+ * lands here — Raster models it as a null query field with no error, so
+ * callers check their own field for null.
  */
-export class RasterNotFoundError extends Error {
-  readonly notFound = true as const;
-  constructor(path: string) {
-    super(`Raster: not found (${path})`);
-    this.name = 'RasterNotFoundError';
+async function rasterQuery<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  logger.debug(`[Raster] POST ${RASTER_GRAPHQL_URL} ${JSON.stringify(variables)}`);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': USER_AGENT,
+  };
+  const apiKey = process.env.RASTER_API_KEY;
+  if (apiKey) {
+    headers['x-api-key'] = apiKey;
   }
-}
-
-async function rasterFetch<T>(path: string): Promise<T> {
-  const url = `${RASTER_BASE_URL}${path}`;
-  logger.debug(`[Raster] GET ${url}`);
-  const response = await fetch(url, {
-    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+  const response = await fetch(RASTER_GRAPHQL_URL, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables }),
   });
-  if (response.status === 404) {
-    throw new RasterNotFoundError(path);
-  }
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(
-      `Raster API ${response.status} ${response.statusText} for ${path}: ${body.slice(0, 200)}`
-    );
+    throw new Error(`Raster API ${response.status} ${response.statusText}: ${body.slice(0, 200)}`);
   }
-  return (await response.json()) as T;
+  const payload = (await response.json()) as { data?: T; errors?: Array<{ message: string }> };
+  if (payload.errors && payload.errors.length > 0) {
+    throw new Error(`Raster API error: ${payload.errors.map((e) => e.message).join('; ')}`);
+  }
+  if (payload.data === undefined) {
+    throw new Error('Raster API returned no data.');
+  }
+  return payload.data;
 }
 
-interface TokenLookupResponse {
-  id: number;
-  contract_address: string;
-  token_id: string;
-  title: string;
-  artwork: {
-    id: number;
-    title: string;
-    artists: RasterArtist[];
-    is_edition: boolean;
-    edition_size: number;
-  };
+interface ArtistFields {
+  id: string;
+  name: string | null;
+  slug: string | null;
 }
 
-interface ArtworkResponse {
-  id: number;
-  title: string;
-  artists: RasterArtist[];
-  token_count: number;
-  edition_size: number;
-  is_edition: boolean;
-  has_one_of_one_tokens: boolean;
-  contract_addresses: string[];
-  platforms: Array<{ id: string; label: string }>;
-}
-
-interface ArtworkTokensResponse {
-  tokens: Array<{
-    chain_id: string;
-    contract_address: string;
-    token_id: string;
-  }>;
-  total_count: number;
-  cursor: number | null;
-}
-
-interface ArtistArtworksResponse {
-  artworks: Array<{
-    id: number;
-    title: string;
-    num_tokens: number;
-    num_pieces: number;
-    is_edition: boolean;
-    mint_date: string | null;
-  }>;
-}
-
-interface SearchResponse {
-  results: Array<{
-    hits: Array<{
-      document: {
-        id: string;
-        data_pk: string;
-        data_type: 'artist' | 'artwork';
-        title: string;
-        addresses?: string[];
-        aliases?: string[];
-      };
-    }>;
-  }>;
+function toRasterArtist(raw: ArtistFields): RasterArtist {
+  return { id: raw.id, name: raw.name ?? 'Unknown artist', slug: raw.slug };
 }
 
 /**
- * Resolve a token's on-chain coordinates to its Raster artwork (series) id.
+ * Resolve a token's on-chain coordinates to its Raster artwork (series).
  *
- * Accepts either a CAIP chain id (`eip155:1`) or human slug (`ethereum`) —
- * Raster handles both. Returns `null` when Raster doesn't index this token
- * (HTTP 404); callers can fall back to a single-token playlist in that case.
- * Other Raster errors throw normally.
+ * One round trip: `tokenByRef` returns the artwork with artists inline, so
+ * this yields the full summary directly. Returns `null` when Raster doesn't
+ * index this token; callers fall back to a single-token playlist in that
+ * case. Tokens occasionally belong to multiple artworks; the first one is
+ * Raster's primary association.
  */
 export async function resolveTokenToArtwork(
-  chain: string,
+  chain: IndexerChain,
   contract: string,
   tokenId: string
-): Promise<{ artworkId: number; artworkTitle: string } | null> {
-  const path =
-    `/token/${encodeURIComponent(chain)}` +
-    `/${encodeURIComponent(contract)}` +
-    `/${encodeURIComponent(tokenId)}`;
-  try {
-    const data = await rasterFetch<TokenLookupResponse>(path);
-    return {
-      artworkId: data.artwork.id,
-      artworkTitle: data.artwork.title,
-    };
-  } catch (error) {
-    if (error instanceof RasterNotFoundError) {
-      return null;
+): Promise<RasterArtworkSummary | null> {
+  const data = await rasterQuery<{
+    tokenByRef: {
+      artworks: Array<{
+        id: string;
+        title: string;
+        artists: ArtistFields[];
+      }>;
+    } | null;
+  }>(
+    `query ResolveToken($ref: TokenRefInput!) {
+      tokenByRef(ref: $ref) {
+        artworks { id title artists { id name slug } }
+      }
+    }`,
+    {
+      ref: {
+        chainId: INDEXER_CHAIN_TO_CAIP[chain],
+        contractAddress: contract,
+        tokenId,
+      },
     }
-    throw error;
-  }
-}
+  );
 
-/**
- * Get the full Raster artwork summary suitable for the one-line resolve
- * message ("Snowfro — send/receive — 8977 tokens") and downstream UX.
- */
-export async function getArtworkSummary(artworkId: number): Promise<RasterArtworkSummary> {
-  const data = await rasterFetch<ArtworkResponse>(`/artwork/${artworkId}`);
+  const artwork = data.tokenByRef?.artworks?.[0];
+  if (!artwork) {
+    return null;
+  }
   return {
-    artworkId: data.id,
-    title: data.title,
-    artists: data.artists ?? [],
-    tokenCount: data.token_count,
-    editionSize: data.edition_size,
-    isEdition: data.is_edition,
-    hasOneOfOneTokens: data.has_one_of_one_tokens,
-    platforms: data.platforms ?? [],
-    contractAddresses: data.contract_addresses ?? [],
+    artworkId: artwork.id,
+    title: artwork.title,
+    artists: (artwork.artists ?? []).map(toRasterArtist),
   };
 }
 
 /**
- * Resolve an artist's wallet address to a Raster artist id via `/search`.
+ * Resolve a wallet address to the Raster artist who claims it.
  *
- * `/artist/{id}` does not accept raw addresses (404), so we bridge through
- * the multi-search endpoint and pick the artist hit whose `addresses` list
- * contains the input. Returns `null` when no artist matches.
+ * The `address` query carries artist associations directly (the old REST
+ * API needed a `/search` bridge). Returns `null` when no artist claims the
+ * address. Checksummed Ethereum input is normalized server-side.
  */
-export async function resolveAddressToArtist(address: string): Promise<number | null> {
-  const normalized = address.trim().toLowerCase();
-  const data = await rasterFetch<SearchResponse>(`/search?query=${encodeURIComponent(address)}`);
+export async function resolveAddressToArtist(address: string): Promise<RasterArtist | null> {
+  const data = await rasterQuery<{
+    address: { artists: ArtistFields[] } | null;
+  }>(
+    `query ResolveAddress($address: String!) {
+      address(address: $address) { artists { id name slug } }
+    }`,
+    { address: address.trim() }
+  );
 
-  for (const result of data.results ?? []) {
-    for (const hit of result.hits ?? []) {
-      const doc = hit.document;
-      if (doc.data_type !== 'artist') {
-        continue;
-      }
-      const addrs = (doc.addresses ?? []).map((a) => a.toLowerCase());
-      if (!addrs.includes(normalized)) {
-        continue;
-      }
-      const parsed = Number.parseInt(doc.data_pk, 10);
-      if (Number.isFinite(parsed)) {
-        return parsed;
-      }
-    }
-  }
-  return null;
+  const artist = data.address?.artists?.[0];
+  return artist ? toRasterArtist(artist) : null;
 }
 
 /**
@@ -262,79 +202,111 @@ export async function resolveAddressToArtist(address: string): Promise<number | 
  * warn-skip line instead of one per token.
  *
  * Pagination: pass the returned `nextCursor` back as `options.cursor`.
- * `nextCursor` is `null` on the final page. Raster signals end-of-stream by
- * returning `cursor === total_count`; that is normalized to `null` here.
+ * `nextCursor` is `null` on the final page. The API exposes no total count;
+ * the only way to learn a series' size is to walk it.
  */
 export async function listArtworkTokens(
-  artworkId: number,
-  options: { cursor?: number; pageSize?: number } = {}
+  artworkId: string,
+  options: { cursor?: string; pageSize?: number } = {}
 ): Promise<PaginatedTokens> {
-  const params = new URLSearchParams();
-  if (options.cursor !== undefined) {
-    params.set('cursor', String(options.cursor));
-  }
-  if (options.pageSize !== undefined) {
-    params.set('page_size', String(options.pageSize));
-  }
-  const qs = params.toString();
-  const path = `/artwork/${artworkId}/tokens${qs ? `?${qs}` : ''}`;
+  const data = await rasterQuery<{
+    artwork: {
+      tokens: {
+        nodes: Array<{ chainId: string; contractAddress: string | null; tokenId: string }>;
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      };
+    } | null;
+  }>(
+    `query ArtworkTokens($id: ID!, $first: Int, $after: String) {
+      artwork(id: $id) {
+        tokens(first: $first, after: $after) {
+          nodes { chainId contractAddress tokenId }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }`,
+    { id: artworkId, first: options.pageSize ?? null, after: options.cursor ?? null }
+  );
 
-  const data = await rasterFetch<ArtworkTokensResponse>(path);
+  if (!data.artwork) {
+    throw new Error(`Raster: artwork ${artworkId} not found.`);
+  }
 
   const tokens: RasterTokenCoords[] = [];
   let skippedUnsupported = 0;
-  for (const raw of data.tokens ?? []) {
-    const chain = caipToIndexerChain(raw.chain_id);
-    if (!chain) {
+  for (const raw of data.artwork.tokens.nodes) {
+    const chain = caipToIndexerChain(raw.chainId);
+    if (!chain || !raw.contractAddress) {
       skippedUnsupported += 1;
       continue;
     }
     tokens.push({
-      caipChain: raw.chain_id,
+      caipChain: raw.chainId,
       chain,
-      contractAddress: stripContractChainPrefix(raw.contract_address),
-      tokenId: raw.token_id,
+      contractAddress: raw.contractAddress,
+      tokenId: raw.tokenId,
     });
   }
 
-  const rawCursor = data.cursor;
-  const nextCursor = rawCursor === null || rawCursor >= data.total_count ? null : rawCursor;
-
+  const { hasNextPage, endCursor } = data.artwork.tokens.pageInfo;
   return {
     tokens,
-    totalCount: data.total_count,
-    nextCursor,
+    nextCursor: hasNextPage && endCursor ? endCursor : null,
     skippedUnsupported,
   };
 }
 
 /**
- * List an artist's full catalog as light artwork rows (id, title, token count,
- * edition flag, mint date). Use {@link getArtworkSummary} when full details
- * are needed for a specific row.
+ * List an artist's full catalog as light artwork rows (id + title — the
+ * API exposes no per-artwork token counts or mint dates yet).
  *
- * The endpoint returns the full catalog in a single response; no cursor is
- * exposed by Raster for this path.
+ * Walks the artist's `artworks` connection to the end so the caller sees
+ * the complete catalog, matching the old single-response REST behavior.
  */
-export async function listArtistArtworks(artistId: number): Promise<RasterArtworkRow[]> {
-  const data = await rasterFetch<ArtistArtworksResponse>(`/artist/${artistId}/artworks`);
-  return (data.artworks ?? []).map((row) => ({
-    artworkId: row.id,
-    title: row.title,
-    tokenCount: row.num_tokens ?? row.num_pieces ?? 0,
-    isEdition: row.is_edition,
-    mintDate: row.mint_date ?? null,
-  }));
+export async function listArtistArtworks(artistId: string): Promise<RasterArtworkRow[]> {
+  const rows: RasterArtworkRow[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const data: {
+      artist: {
+        artworks: {
+          nodes: Array<{ id: string; title: string }>;
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        };
+      } | null;
+    } = await rasterQuery(
+      `query ArtistArtworks($id: ID!, $after: String) {
+        artist(id: $id) {
+          artworks(first: 100, after: $after) {
+            nodes { id title }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`,
+      { id: artistId, after: cursor }
+    );
+
+    if (!data.artist) {
+      throw new Error(`Raster: artist ${artistId} not found.`);
+    }
+    for (const node of data.artist.artworks.nodes) {
+      rows.push({ artworkId: node.id, title: node.title });
+    }
+    const { hasNextPage, endCursor } = data.artist.artworks.pageInfo;
+    cursor = hasNextPage && endCursor ? endCursor : null;
+  } while (cursor !== null);
+
+  return rows;
 }
 
 /**
  * Format a one-line summary for the resolved artwork.
  *
  * @example
- *   formatSummaryLine(summary) // "Snowfro — send/receive — 8977 tokens"
+ *   formatSummaryLine(summary) // "Snowfro — send/receive"
  */
 export function formatSummaryLine(summary: RasterArtworkSummary): string {
   const artistNames = summary.artists.map((a) => a.name).join(', ') || 'Unknown artist';
-  const tokenWord = summary.tokenCount === 1 ? 'token' : 'tokens';
-  return `${artistNames} — ${summary.title} — ${summary.tokenCount} ${tokenWord}`;
+  return `${artistNames} — ${summary.title}`;
 }

--- a/tests/find-command.test.ts
+++ b/tests/find-command.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Command-level tests for the `ff-cli find` series flow against a mock
+ * Raster GraphQL server (wired in via the RASTER_API_URL override).
+ *
+ * The Raster client unit tests (find-resolvers.test.ts) lock in response
+ * parsing; these cover the user-visible behavior of the command itself:
+ * the confirm prompt text for complete vs capped series, the --output
+ * prompt bypass, the single-token fallback messaging, and the
+ * zero-supported-tokens failure exit.
+ *
+ * All prompts are answered "n" (or bypassed and the child killed once the
+ * flow provably passed the prompt), so no test reaches the FF indexer —
+ * the suite stays hermetic.
+ */
+
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, test } from 'node:test';
+import { spawn } from 'node:child_process';
+import { createServer, Server } from 'node:http';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const projectRoot = resolve(__dirname, '..');
+// Spawn node directly with tsx's JS entry to avoid Windows .cmd shim
+// limitations in spawn (Node refuses to execute .bat/.cmd without shell).
+const tsxCli = resolve(projectRoot, 'node_modules/tsx/dist/cli.mjs');
+const cliEntry = resolve(projectRoot, 'index.ts');
+
+type GraphQLHandler = (query: string, variables: Record<string, unknown>) => unknown;
+
+let server: Server;
+let serverUrl: string;
+let handler: GraphQLHandler;
+
+before(async () => {
+  server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      const { query, variables } = JSON.parse(body) as {
+        query: string;
+        variables: Record<string, unknown>;
+      };
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(handler(query, variables ?? {})));
+    });
+  });
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('mock Raster server did not bind to a port');
+  }
+  serverUrl = `http://127.0.0.1:${address.port}/graphql`;
+});
+
+after(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  handler = () => ({ errors: [{ message: 'no handler installed for this test' }] });
+});
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  /** Process exit code; null when the run was killed via `killOn`. */
+  code: number | null;
+}
+
+/**
+ * Run `ff-cli find <args>` against the mock Raster server.
+ *
+ * `stdin` is written to the child's stdin and closed (prompt answers).
+ * `killOn` kills the child once stdout matches — used to stop a run that
+ * has provably passed the assertion point but would otherwise continue
+ * into the (hardcoded, network) FF indexer.
+ */
+function runFind(
+  args: string[],
+  options: { stdin?: string; killOn?: RegExp } = {}
+): Promise<RunResult> {
+  return new Promise((resolveRun, rejectRun) => {
+    const dir = mkdtempSync(join(tmpdir(), 'ff-find-cmd-'));
+    const child = spawn(process.execPath, [tsxCli, cliEntry, 'find', ...args], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        RASTER_API_URL: serverUrl,
+        FORCE_COLOR: '0',
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const finish = (result: RunResult | Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      rmSync(dir, { recursive: true, force: true });
+      if (result instanceof Error) {
+        rejectRun(result);
+      } else {
+        resolveRun(result);
+      }
+    };
+
+    // Hermeticity backstop: a hung prompt or an unexpected network call
+    // should fail the test, not stall the suite.
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(new Error(`find timed out.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, 30_000);
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (options.killOn && options.killOn.test(stdout)) {
+        child.kill('SIGKILL');
+        finish({ stdout, stderr, code: null });
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', finish);
+    child.on('close', (code) => finish({ stdout, stderr, code }));
+
+    child.stdin.write(options.stdin ?? '');
+    child.stdin.end();
+  });
+}
+
+/** tokenByRef response: token belongs to a Raster-indexed series. */
+const SERIES_HIT = {
+  data: {
+    tokenByRef: {
+      artworks: [
+        {
+          id: '42',
+          title: 'Test Series',
+          artists: [{ id: '7', name: 'Test Artist', slug: 'test-artist' }],
+        },
+      ],
+    },
+  },
+};
+
+function tokensPage(
+  nodes: Array<{ chainId: string; contractAddress: string; tokenId: string }>,
+  hasNextPage: boolean
+): unknown {
+  return {
+    data: {
+      artwork: {
+        tokens: {
+          nodes,
+          pageInfo: { hasNextPage, endCursor: hasNextPage ? 'next-cursor' : null },
+        },
+      },
+    },
+  };
+}
+
+const ETH_TOKEN = (
+  tokenId: string
+): { chainId: string; contractAddress: string; tokenId: string } => ({
+  chainId: 'eip155:1',
+  contractAddress: '0xabc',
+  tokenId,
+});
+
+describe('find command — Raster series flow (mock GraphQL server)', () => {
+  test('complete series → "Build playlist with N tokens?" prompt; "n" cancels before indexing', async () => {
+    handler = (query) => {
+      if (query.includes('tokenByRef')) {
+        return SERIES_HIT;
+      }
+      return tokensPage([ETH_TOKEN('1'), ETH_TOKEN('2')], false);
+    };
+    const result = await runFind(['ethereum:0xabc:1'], { stdin: 'n\n' });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /Test Artist — Test Series/);
+    assert.match(result.stdout, /Build playlist with 2 tokens\?/);
+    assert.doesNotMatch(result.stdout, /the first/);
+    assert.match(result.stdout, /Cancelled\./);
+    assert.doesNotMatch(result.stdout, /Indexing/);
+  });
+
+  test('--limit below series size → "the first N tokens" prompt wording', async () => {
+    handler = (query) => {
+      if (query.includes('tokenByRef')) {
+        return SERIES_HIT;
+      }
+      // One page holding more tokens than the limit: the truncation is
+      // detected from leftover rows, with more pages still advertised.
+      return tokensPage([ETH_TOKEN('1'), ETH_TOKEN('2'), ETH_TOKEN('3')], true);
+    };
+    const result = await runFind(['ethereum:0xabc:1', '--limit', '2'], { stdin: 'n\n' });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /Build playlist with the first 2 tokens\?/);
+    assert.match(result.stdout, /Cancelled\./);
+  });
+
+  test('--output bypasses the confirm prompt and proceeds to indexing', async () => {
+    handler = (query) => {
+      if (query.includes('tokenByRef')) {
+        return SERIES_HIT;
+      }
+      return tokensPage([ETH_TOKEN('1'), ETH_TOKEN('2')], false);
+    };
+    // killOn stops the run once it has provably passed the prompt — the
+    // next step would call the real FF indexer.
+    const result = await runFind(['ethereum:0xabc:1', '--output', 'out.json'], {
+      killOn: /Indexing 2 tokens via FF indexer/,
+    });
+    assert.equal(result.code, null);
+    assert.doesNotMatch(result.stdout, /Build playlist with/);
+  });
+
+  test('series with only unsupported-chain tokens → clear error, exit 1', async () => {
+    handler = (query) => {
+      if (query.includes('tokenByRef')) {
+        return SERIES_HIT;
+      }
+      return tokensPage(
+        [
+          { chainId: 'eip155:137', contractAddress: '0xmatic', tokenId: '1' },
+          { chainId: 'eip155:8453', contractAddress: '0xbase', tokenId: '2' },
+        ],
+        false
+      );
+    };
+    const result = await runFind(['ethereum:0xabc:1'], { stdin: 'n\n' });
+    assert.equal(result.code, 1);
+    assert.match(result.stdout, /Skipped 2 tokens on unsupported chains/);
+    assert.match(result.stderr, /Series has no tokens on supported chains/);
+  });
+
+  test('unindexed token → single-token fallback messaging and 1-token prompt', async () => {
+    handler = (query) => {
+      if (query.includes('tokenByRef')) {
+        return { data: { tokenByRef: null } };
+      }
+      return { errors: [{ message: 'unexpected query for single-token path' }] };
+    };
+    const result = await runFind(['ethereum:0xabc:1'], { stdin: 'n\n' });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /Single token — ethereum 0xabc:1/);
+    assert.match(result.stdout, /Raster doesn't index this series/);
+    assert.match(result.stdout, /Build playlist with 1 token\?/);
+    assert.match(result.stdout, /Cancelled\./);
+  });
+});

--- a/tests/find-command.test.ts
+++ b/tests/find-command.test.ts
@@ -97,6 +97,8 @@ function runFind(
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let killedByMatcher = false;
+    let timedOut = false;
 
     const finish = (result: RunResult | Error): void => {
       if (settled) {
@@ -104,7 +106,13 @@ function runFind(
       }
       settled = true;
       clearTimeout(timer);
-      rmSync(dir, { recursive: true, force: true });
+      // On Windows the just-killed child can briefly hold its cwd open
+      // (EBUSY); retry, and prefer leaking a temp dir over a flaky test.
+      try {
+        rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      } catch {
+        // best-effort cleanup only
+      }
       if (result instanceof Error) {
         rejectRun(result);
       } else {
@@ -113,24 +121,31 @@ function runFind(
     };
 
     // Hermeticity backstop: a hung prompt or an unexpected network call
-    // should fail the test, not stall the suite.
+    // should fail the test, not stall the suite. Resolution happens in the
+    // 'close' handler so the child is fully gone before cleanup.
     const timer = setTimeout(() => {
+      timedOut = true;
       child.kill('SIGKILL');
-      finish(new Error(`find timed out.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
     }, 30_000);
 
     child.stdout.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
-      if (options.killOn && options.killOn.test(stdout)) {
+      if (options.killOn && !killedByMatcher && options.killOn.test(stdout)) {
+        killedByMatcher = true;
         child.kill('SIGKILL');
-        finish({ stdout, stderr, code: null });
       }
     });
     child.stderr.on('data', (chunk: Buffer) => {
       stderr += chunk.toString();
     });
     child.on('error', finish);
-    child.on('close', (code) => finish({ stdout, stderr, code }));
+    child.on('close', (code) => {
+      if (timedOut) {
+        finish(new Error(`find timed out.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      } else {
+        finish({ stdout, stderr, code: killedByMatcher ? null : code });
+      }
+    });
 
     child.stdin.write(options.stdin ?? '');
     child.stdin.end();

--- a/tests/find-resolvers.test.ts
+++ b/tests/find-resolvers.test.ts
@@ -21,7 +21,12 @@ import { resolveFxhashIteration, resolveFxhashProject } from '../src/utilities/f
 import { resolveNeortArt } from '../src/utilities/neort-marketplace';
 import { resolveFeralFileToken } from '../src/utilities/ff-marketplace';
 import { resolveVerseSeries } from '../src/utilities/verse-marketplace';
-import { resolveTokenToArtwork, listArtworkTokens } from '../src/utilities/raster-client';
+import {
+  resolveTokenToArtwork,
+  listArtworkTokens,
+  listArtistArtworks,
+  resolveAddressToArtist,
+} from '../src/utilities/raster-client';
 
 type FetchFn = typeof global.fetch;
 
@@ -56,77 +61,103 @@ async function withMockedFetch<T>(mock: FetchFn, run: () => Promise<T>): Promise
   }
 }
 
-describe('resolveTokenToArtwork (Raster)', () => {
-  test('200 → resolves to artworkId + title', async () => {
-    const mock = mockFetchByUrl([
-      {
-        match: '/token/ethereum/0xabc/123',
-        body: {
-          id: 1,
-          contract_address: '0xabc',
-          token_id: '123',
-          title: 'Token #123',
-          artwork: {
-            id: 42,
-            title: 'Send/Receive',
-            artists: [],
-            is_edition: false,
-            edition_size: 1,
+/**
+ * Build a fetch mock for the Raster GraphQL endpoint. All Raster calls POST
+ * to one URL, so routing keys off the request body (query text + variables)
+ * instead of the URL. The handler returns the JSON payload to serve
+ * (`{ data }` or `{ errors }`); pass `status` to simulate HTTP failures.
+ */
+function mockRasterGraphQL(
+  handler: (query: string, variables: Record<string, unknown>) => unknown,
+  status = 200
+): FetchFn {
+  return (async (_input: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as {
+      query?: string;
+      variables?: Record<string, unknown>;
+    };
+    return new Response(JSON.stringify(handler(body.query ?? '', body.variables ?? {})), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as FetchFn;
+}
+
+describe('resolveTokenToArtwork (Raster GraphQL)', () => {
+  test('indexed token → full summary (id, title, artists) in one query', async () => {
+    let seenRef: Record<string, unknown> | undefined;
+    const mock = mockRasterGraphQL((_query, variables) => {
+      seenRef = variables.ref as Record<string, unknown>;
+      return {
+        data: {
+          tokenByRef: {
+            artworks: [
+              {
+                id: '42',
+                title: 'Send/Receive',
+                artists: [{ id: '7', name: 'Snowfro', slug: 'snowfro' }],
+              },
+            ],
           },
         },
-      },
-    ]);
+      };
+    });
     const result = await withMockedFetch(mock, () =>
       resolveTokenToArtwork('ethereum', '0xabc', '123')
     );
     assert.notEqual(result, null);
-    assert.equal(result?.artworkId, 42);
-    assert.equal(result?.artworkTitle, 'Send/Receive');
+    assert.equal(result?.artworkId, '42');
+    assert.equal(result?.title, 'Send/Receive');
+    assert.equal(result?.artists[0]?.name, 'Snowfro');
+    // Indexer chain slugs must be translated to CAIP-2 for the API.
+    assert.deepEqual(seenRef, { chainId: 'eip155:1', contractAddress: '0xabc', tokenId: '123' });
   });
 
-  test('404 → returns null (caller falls back to single-token mode)', async () => {
-    const mock = mockFetchByUrl([
-      { match: '/token/', status: 404, body: { detail: 'Token not found' } },
-    ]);
+  test('unindexed token → tokenByRef null → returns null (caller falls back to single-token mode)', async () => {
+    const mock = mockRasterGraphQL(() => ({ data: { tokenByRef: null } }));
     const result = await withMockedFetch(mock, () =>
       resolveTokenToArtwork('ethereum', '0xabc', '123')
     );
     assert.equal(result, null);
   });
 
-  test('500 → throws (non-404 errors propagate)', async () => {
-    const mock = mockFetchByUrl([
-      { match: '/token/', status: 500, body: { detail: 'internal error' } },
-    ]);
+  test('HTTP 500 → throws', async () => {
+    const mock = mockRasterGraphQL(() => ({ detail: 'internal error' }), 500);
     await assert.rejects(
       () => withMockedFetch(mock, () => resolveTokenToArtwork('ethereum', '0xabc', '123')),
       /500/
     );
   });
+
+  test('GraphQL errors → throws with concatenated messages', async () => {
+    const mock = mockRasterGraphQL(() => ({
+      errors: [{ message: 'invalid API key' }, { message: 'rate limited' }],
+    }));
+    await assert.rejects(
+      () => withMockedFetch(mock, () => resolveTokenToArtwork('ethereum', '0xabc', '123')),
+      /invalid API key; rate limited/
+    );
+  });
 });
 
-describe('listArtworkTokens (Raster — pagination + chain filter)', () => {
+describe('listArtworkTokens (Raster GraphQL — pagination + chain filter)', () => {
   test('eth + tezos tokens pass through, unsupported chains counted in skippedUnsupported', async () => {
-    const mock = mockFetchByUrl([
-      {
-        match: '/artwork/42/tokens',
-        body: {
-          tokens: [
-            { chain_id: 'eip155:1', contract_address: 'eip155:1/0xeth', token_id: '1' },
-            {
-              chain_id: 'tezos:NetXdQprcVkpaWU',
-              contract_address: 'tezos:NetXdQprcVkpaWU/KT1abc',
-              token_id: '2',
-            },
-            { chain_id: 'eip155:137', contract_address: 'eip155:137/0xmatic', token_id: '3' },
-            { chain_id: 'eip155:8453', contract_address: 'eip155:8453/0xbase', token_id: '4' },
-          ],
-          total_count: 4,
-          cursor: 4,
+    const mock = mockRasterGraphQL(() => ({
+      data: {
+        artwork: {
+          tokens: {
+            nodes: [
+              { chainId: 'eip155:1', contractAddress: '0xeth', tokenId: '1' },
+              { chainId: 'tezos:NetXdQprcVkpaWU', contractAddress: 'KT1abc', tokenId: '2' },
+              { chainId: 'eip155:137', contractAddress: '0xmatic', tokenId: '3' },
+              { chainId: 'eip155:8453', contractAddress: '0xbase', tokenId: '4' },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: 'opaque-end' },
+          },
         },
       },
-    ]);
-    const page = await withMockedFetch(mock, () => listArtworkTokens(42));
+    }));
+    const page = await withMockedFetch(mock, () => listArtworkTokens('42'));
     assert.equal(page.tokens.length, 2);
     assert.equal(page.tokens[0].chain, 'ethereum');
     assert.equal(page.tokens[0].contractAddress, '0xeth');
@@ -135,34 +166,111 @@ describe('listArtworkTokens (Raster — pagination + chain filter)', () => {
     assert.equal(page.skippedUnsupported, 2);
   });
 
-  test('cursor === total_count → nextCursor null (end of stream)', async () => {
-    const mock = mockFetchByUrl([
-      {
-        match: '/artwork/42/tokens',
-        body: {
-          tokens: [{ chain_id: 'eip155:1', contract_address: 'eip155:1/0xa', token_id: '1' }],
-          total_count: 100,
-          cursor: 100,
+  test('hasNextPage false → nextCursor null (end of stream)', async () => {
+    const mock = mockRasterGraphQL(() => ({
+      data: {
+        artwork: {
+          tokens: {
+            nodes: [{ chainId: 'eip155:1', contractAddress: '0xa', tokenId: '1' }],
+            pageInfo: { hasNextPage: false, endCursor: 'cursor-a' },
+          },
         },
       },
-    ]);
-    const page = await withMockedFetch(mock, () => listArtworkTokens(42));
+    }));
+    const page = await withMockedFetch(mock, () => listArtworkTokens('42'));
     assert.equal(page.nextCursor, null);
   });
 
-  test('cursor < total_count → nextCursor passes through for next page', async () => {
-    const mock = mockFetchByUrl([
-      {
-        match: '/artwork/42/tokens',
-        body: {
-          tokens: [{ chain_id: 'eip155:1', contract_address: 'eip155:1/0xa', token_id: '1' }],
-          total_count: 100,
-          cursor: 50,
+  test('hasNextPage true → endCursor passes through for next page', async () => {
+    const mock = mockRasterGraphQL((_query, variables) => ({
+      data: {
+        artwork: {
+          tokens: {
+            nodes: [{ chainId: 'eip155:1', contractAddress: '0xa', tokenId: '1' }],
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: `cursor-after-${variables.after ?? 'start'}`,
+            },
+          },
         },
       },
+    }));
+    const page = await withMockedFetch(mock, () => listArtworkTokens('42'));
+    assert.equal(page.nextCursor, 'cursor-after-start');
+
+    const next = await withMockedFetch(mock, () =>
+      listArtworkTokens('42', { cursor: page.nextCursor! })
+    );
+    assert.equal(next.nextCursor, 'cursor-after-cursor-after-start');
+  });
+
+  test('unknown artwork id → throws', async () => {
+    const mock = mockRasterGraphQL(() => ({ data: { artwork: null } }));
+    await assert.rejects(
+      () => withMockedFetch(mock, () => listArtworkTokens('999')),
+      /artwork 999 not found/
+    );
+  });
+});
+
+describe('resolveAddressToArtist (Raster GraphQL)', () => {
+  test('claimed address → first associated artist', async () => {
+    const mock = mockRasterGraphQL(() => ({
+      data: { address: { artists: [{ id: '2', name: 'Snowfro', slug: 'snowfro' }] } },
+    }));
+    const artist = await withMockedFetch(mock, () =>
+      resolveAddressToArtist('0xf3860788d1597cecf938424baabe976fac87dc26')
+    );
+    assert.deepEqual(artist, { id: '2', name: 'Snowfro', slug: 'snowfro' });
+  });
+
+  test('unclaimed address → empty artists list → null', async () => {
+    const mock = mockRasterGraphQL(() => ({ data: { address: { artists: [] } } }));
+    const artist = await withMockedFetch(mock, () => resolveAddressToArtist('0xdeadbeef'));
+    assert.equal(artist, null);
+  });
+});
+
+describe('listArtistArtworks (Raster GraphQL — full catalog walk)', () => {
+  test('paginates until hasNextPage is false and concatenates rows', async () => {
+    const mock = mockRasterGraphQL((_query, variables) => {
+      if (!variables.after) {
+        return {
+          data: {
+            artist: {
+              artworks: {
+                nodes: [{ id: '1', title: 'First' }],
+                pageInfo: { hasNextPage: true, endCursor: 'page-2' },
+              },
+            },
+          },
+        };
+      }
+      assert.equal(variables.after, 'page-2');
+      return {
+        data: {
+          artist: {
+            artworks: {
+              nodes: [{ id: '2', title: 'Second' }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      };
+    });
+    const rows = await withMockedFetch(mock, () => listArtistArtworks('7'));
+    assert.deepEqual(rows, [
+      { artworkId: '1', title: 'First' },
+      { artworkId: '2', title: 'Second' },
     ]);
-    const page = await withMockedFetch(mock, () => listArtworkTokens(42));
-    assert.equal(page.nextCursor, 50);
+  });
+
+  test('unknown artist id → throws', async () => {
+    const mock = mockRasterGraphQL(() => ({ data: { artist: null } }));
+    await assert.rejects(
+      () => withMockedFetch(mock, () => listArtistArtworks('404')),
+      /artist 404 not found/
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Raster shipped a public GraphQL API ([docs.api.raster.art](https://docs.api.raster.art/)) intended to replace direct use of the pre-public REST surface at `kit.raster.art`. This migrates the `find` flow's Raster client to it.

## What changed

**Client (`src/utilities/raster-client.ts`)** — rewritten against `https://api.raster.art/graphql`:

- `tokenByRef` returns the artwork with artists inline, so token → series resolution is now **one round trip** (was two REST calls: `/token/...` + `/artwork/{id}`).
- `address(address:)` resolves artist wallets directly, replacing the old `/search` bridge. Checksummed input is normalized server-side.
- Raster IDs are opaque strings (`ID` scalar), chain refs are CAIP-2 only (`eip155:1`, `tezos:NetXdQprcVkpaWU`), and not-found is a `null` field rather than HTTP 404 — `RasterNotFoundError` is gone.
- Cursor pagination via `pageInfo { hasNextPage endCursor }`; artist catalogs are walked page-by-page.
- Optional auth: `RASTER_API_KEY` is sent as `x-api-key` when set (the docs declare a key required; the endpoint doesn't enforce one yet). `RASTER_API_URL` overrides the endpoint. Documented in `docs/CONFIGURATION.md`.

**Find flow (`src/commands/find.ts`)** — the new API exposes **no token counts** on connections, so the flow can no longer say "Build playlist with X of 8977 tokens?" before fetching. It now enumerates series tokens first (up to the DP-1 cap of 1024) and confirms with the actual fetched count ("the first N tokens" when the series continues past the limit). The artist catalog picker lists titles without per-artwork token counts, and a series whose tokens are all on unsupported chains now fails with a clear message instead of falling through to the indexer.

**Tests** — Raster suites rewritten for the GraphQL shapes with a body-routing fetch mock (all calls POST to one URL); covers CAIP translation, null-field not-found, GraphQL error propagation, chain filtering, cursor pagination, and catalog walking.

## Verified live

- Art Blocks token URL → "Snowfro — Chromie Squiggle" series → 3-item playlist
- Snowfro wallet address → 11-artwork catalog (paginated) → pick → playlist
- Objkt/Tezos token (hicetnunc) → series via `tezos:NetXdQprcVkpaWU` ref
- Unindexed token → single-token fallback

## Known gaps (reported upstream to Raster)

- No `totalCount` on connections — series size is only learnable by walking.
- No edition metadata (`is_edition`, `edition_size`, `mint_date`) on artworks.
- No search query (slug/ID lookups only) — not blocking, `address()` covers our artist path.