### PR TITLE
feat: support Raster (raster.art) artworks in find, with FF-indexer bypass

### DIFF
--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -15,6 +15,7 @@ import type { NeortArt } from '../utilities/neort-marketplace';
 import { resolveVerseSeries } from '../utilities/verse-marketplace';
 import {
   resolveTokenToArtwork,
+  resolveSlugToArtwork,
   listArtworkTokens,
   listArtistArtworks,
   resolveAddressToArtist,
@@ -61,13 +62,21 @@ type ResolvedTarget =
   | { kind: 'series'; summary: RasterArtworkSummary }
   | { kind: 'single'; coords: TokenCoords };
 
+/**
+ * A token to build into the playlist. `mediaUrl` is Raster's own playable
+ * asset for the token when known — the find flow falls back to it to build
+ * DP-1 items directly (off-chain provenance) when the FF indexer can't
+ * resolve the tokens, e.g. Raster-minted series the indexer doesn't carry.
+ */
+type BuildToken = TokenCoords & { mediaUrl: string | null; mediaType: string | null };
+
 const RASTER_PAGE_SIZE = 100;
 
 export const findCommand = new Command('find')
   .description('Find an artwork on the web and build a DP-1 playlist')
   .argument(
     '<input>',
-    'URL (Objkt / fxhash / Art Blocks / OpenSea / SuperRare / Feral File / Neort / Verse), `ethereum:{contract}:{tokenId}`, `tezos:{contract}:{tokenId}`, or a wallet address'
+    'URL (Objkt / fxhash / Art Blocks / OpenSea / SuperRare / Feral File / Neort / Verse / Raster), `ethereum:{contract}:{tokenId}`, `tezos:{contract}:{tokenId}`, or a wallet address'
   )
   .option('-o, --output <path>', 'Save the playlist to this file (default: ./<slug>.json)')
   .option('-l, --limit <n>', 'Max tokens to include from the series (default: all)')
@@ -92,7 +101,7 @@ export const findCommand = new Command('find')
         console.error(chalk.red('Could not understand input.'));
         console.error(
           chalk.dim(
-            'Supported URLs: Objkt, fxhash, Art Blocks, OpenSea, SuperRare, Feral File, Neort, Verse. ' +
+            'Supported URLs: Objkt, fxhash, Art Blocks, OpenSea, SuperRare, Feral File, Neort, Verse, Raster. ' +
               'Or: `ethereum:{contract}:{tokenId}`, `tezos:{contract}:{tokenId}`, ' +
               'or a wallet address (`0x...` / `tz1.../tz2.../tz3...`).'
           )
@@ -134,14 +143,14 @@ export const findCommand = new Command('find')
       // Raster's GraphQL API exposes no series token counts, so enumerate
       // tokens first (up to the effective limit) and confirm with the real
       // number afterward. `hasMore` means the series continues past `limit`.
-      let tokens: TokenCoords[];
+      let tokens: BuildToken[];
       let seriesHasMore = false;
       if (target.kind === 'series') {
         const fetched = await fetchTokens(target.summary, limit);
         tokens = fetched.tokens;
         seriesHasMore = fetched.hasMore;
       } else {
-        tokens = [target.coords];
+        tokens = [{ ...target.coords, mediaUrl: null, mediaType: null }];
       }
 
       if (tokens.length === 0) {
@@ -179,13 +188,34 @@ export const findCommand = new Command('find')
       // display seconds), not concurrency — concurrency is hardcoded inside.
       // Omit it for auto timing: video/audio items carry no duration and play
       // their natural length (DP-1 §4.1); static items get the config default.
-      const items = await getNFTTokenInfoBatch(
+      let items = await getNFTTokenInfoBatch(
         tokens.map((t) => ({
           chain: t.chain,
           contractAddress: t.contract,
           tokenId: t.tokenId,
         }))
       );
+
+      // FF-indexer bypass for Raster-minted tokens. The indexer doesn't carry
+      // Raster's tokens, so it returns nothing — but Raster handed us each
+      // token's playable `media.contentUrl`. Build DP-1 items straight from
+      // that (off-chain provenance, same shape as the Neort path), so the
+      // series still builds into a signable, verifiable playlist instead of
+      // failing the way it did before. The indexer is tried first so tokens
+      // it *can* resolve keep their richer on-chain provenance.
+      if (!Array.isArray(items) || items.length === 0) {
+        const rasterItems = buildRasterMediaItems(tokens, target);
+        if (rasterItems.length > 0) {
+          console.log(
+            chalk.dim(
+              `  FF indexer returned nothing; building ${rasterItems.length} item${
+                rasterItems.length === 1 ? '' : 's'
+              } directly from Raster media.`
+            )
+          );
+          items = rasterItems;
+        }
+      }
 
       if (!Array.isArray(items) || items.length === 0) {
         console.error(chalk.red('No tokens could be indexed; cannot build playlist.'));
@@ -265,6 +295,16 @@ async function resolveTarget(
     const coords = await resolveVerseSeries(parsed.slug);
     return resolveCoords(coords);
   }
+  if (parsed.kind === 'raster-artwork') {
+    const summary = await resolveSlugToArtwork(parsed.slug);
+    if (summary === null) {
+      throw new Error(
+        `No artwork found on Raster for slug "${parsed.slug}". ` +
+          'Check the URL — Raster artwork URLs are raster.art/artwork/{slug}.'
+      );
+    }
+    return { kind: 'series', summary };
+  }
   if (parsed.kind === 'address') {
     const artist = await resolveAddressToArtist(parsed.address);
     if (artist === null) {
@@ -312,6 +352,33 @@ function playlistTitleFor(target: ResolvedTarget, items: Array<{ title?: string 
   return items[0]?.title ?? `Token ${target.coords.tokenId}`;
 }
 
+/**
+ * Build DP-1 items directly from Raster's per-token media, bypassing the FF
+ * indexer. Used as a fallback when the indexer resolves nothing — tokens
+ * without a Raster `mediaUrl` are dropped (nothing playable to point at).
+ *
+ * Item shape matches the Neort off-chain path (`buildUrlItem` →
+ * `provenance.offChainURI`), so the resulting playlist signs and verifies
+ * normally. Titles are "<Series> #<tokenId>" for series, falling back to the
+ * series/coords title for a single token.
+ */
+export function buildRasterMediaItems(tokens: BuildToken[], target: ResolvedTarget): unknown[] {
+  const seriesTitle = target.kind === 'series' ? target.summary.title : undefined;
+  const items: unknown[] = [];
+  for (const t of tokens) {
+    if (!t.mediaUrl) {
+      continue;
+    }
+    const title = seriesTitle ? `${seriesTitle} #${t.tokenId}` : `Token ${t.tokenId}`;
+    // No explicit duration: auto timing (video/audio play their natural
+    // length). `mediaType` carries Raster's type so an extensionless IPFS
+    // contentUrl is still classified correctly — otherwise a video would be
+    // stamped a fixed duration and play as a still.
+    items.push(buildUrlItem(t.mediaUrl, undefined, { title, mimeType: t.mediaType ?? undefined }));
+  }
+  return items;
+}
+
 export function parseLimitOption(limitStr: string | undefined): number {
   if (limitStr === undefined) {
     return Number.POSITIVE_INFINITY;
@@ -339,8 +406,8 @@ export function parseLimitOption(limitStr: string | undefined): number {
 async function fetchTokens(
   summary: RasterArtworkSummary,
   limit: number
-): Promise<{ tokens: TokenCoords[]; hasMore: boolean }> {
-  const collected: TokenCoords[] = [];
+): Promise<{ tokens: BuildToken[]; hasMore: boolean }> {
+  const collected: BuildToken[] = [];
   let cursor: string | undefined;
   let skipped = 0;
   let hasMore = false;
@@ -360,6 +427,8 @@ async function fetchTokens(
         chain: t.chain,
         contract: t.contractAddress,
         tokenId: t.tokenId,
+        mediaUrl: t.mediaUrl,
+        mediaType: t.mediaType,
       });
     }
     if (hasMore || page.nextCursor === null) {
@@ -447,7 +516,7 @@ export async function decideActions(options: FindOptions): Promise<PostBuildActi
   return [await promptNextAction()];
 }
 
-export type { FindOptions };
+export type { FindOptions, BuildToken, ResolvedTarget };
 
 async function promptNextAction(): Promise<PostBuildAction> {
   const prompt = createPrompt();

--- a/src/utilities/marketplace-url.ts
+++ b/src/utilities/marketplace-url.ts
@@ -47,6 +47,7 @@ export type ParsedFindInput =
   | { kind: 'fxhash-project'; slug: string }
   | { kind: 'neort-art'; id: string }
   | { kind: 'verse-series'; slug: string }
+  | { kind: 'raster-artwork'; slug: string }
   | { kind: 'unsupported'; reason: string };
 
 const ETH_ADDR = /^0x[a-fA-F0-9]{40}$/;
@@ -127,6 +128,9 @@ export function parseMarketplaceUrl(url: URL): ParsedFindInput | null {
   }
   if (host === 'verse.works' || host.endsWith('.verse.works')) {
     return parseVerse(url);
+  }
+  if (host === 'raster.art' || host.endsWith('.raster.art')) {
+    return parseRaster(url);
   }
   return null;
 }
@@ -427,6 +431,28 @@ export function parseVerse(url: URL): ParsedFindInput {
     reason:
       `Verse URL not recognized: ${url.pathname}. Expected ` +
       '/items/ethereum/{contract}/{tokenId} or /series/{slug}.',
+  };
+}
+
+/**
+ * Raster URL forms (raster.art):
+ *   raster.art/artwork/{slug}   — artwork (series) detail page
+ *
+ * Unlike the other marketplaces, Raster is already the find flow's backend
+ * resolver — so a Raster URL resolves to an artwork by slug via
+ * `artworkBySlug` and (crucially) builds DP-1 items straight from Raster's
+ * own `media.contentUrl`, bypassing the FF indexer the way Neort does. This
+ * is what lets Raster-minted tokens (which the FF indexer doesn't carry)
+ * build a verifiable playlist without `--skip-verify`.
+ */
+export function parseRaster(url: URL): ParsedFindInput {
+  const m = /^\/artwork\/([A-Za-z0-9][A-Za-z0-9_-]*)\/?$/.exec(url.pathname);
+  if (m) {
+    return { kind: 'raster-artwork', slug: m[1] };
+  }
+  return {
+    kind: 'unsupported',
+    reason: `Raster URL not recognized: ${url.pathname}. Expected /artwork/{slug}.`,
   };
 }
 

--- a/src/utilities/playlist-builder.js
+++ b/src/utilities/playlist-builder.js
@@ -579,6 +579,10 @@ function detectMimeType(url) {
  *   (video/audio URLs play their natural length per DP-1 §4.1)
  * @param {Object} [options] - Optional configuration
  * @param {string} [options.title] - Optional item title override
+ * @param {string} [options.mimeType] - Source media type hint for timing
+ *   (DP-1 §4.1). Needed when the URL has no file extension to detect from —
+ *   e.g. extensionless IPFS gateway URLs, where without this hint a video
+ *   would be misclassified as a static image and stamped a fixed duration.
  * @returns {Object} DP1 playlist item
  */
 function buildUrlItem(url, duration, options = {}) {
@@ -626,7 +630,7 @@ function buildUrlItem(url, duration, options = {}) {
     },
   };
 
-  return applyItemTiming(item, { sourceUrl }, duration);
+  return applyItemTiming(item, { sourceUrl, mimeType: options.mimeType }, duration);
 }
 
 module.exports = {

--- a/src/utilities/raster-client.ts
+++ b/src/utilities/raster-client.ts
@@ -65,6 +65,21 @@ export interface RasterTokenCoords {
   chain: IndexerChain;
   contractAddress: string;
   tokenId: string;
+  /**
+   * Raster's own playable asset URL for this token, when present. The find
+   * flow uses it to build a DP-1 item directly (off-chain `provenance`),
+   * bypassing the FF indexer for Raster-minted tokens it cannot resolve.
+   */
+  mediaUrl: string | null;
+  /**
+   * Media type hint for DP-1 timing: Raster's `contentType` when populated,
+   * else its `previewType` (e.g. "video/2"). Raster's `contentUrl` is often
+   * an extensionless IPFS URL, so without this hint the builder can't tell a
+   * video from a still and would stamp it a fixed duration. Both fields share
+   * a standard category prefix (`video/`, `audio/`, `image/`), which is all
+   * the timing check needs.
+   */
+  mediaType: string | null;
 }
 
 export interface PaginatedTokens {
@@ -173,6 +188,41 @@ export async function resolveTokenToArtwork(
 }
 
 /**
+ * Resolve a `raster.art/artwork/{slug}` URL to its artwork (series) summary.
+ *
+ * One round trip via `artworkBySlug`. Returns `null` when the slug is
+ * unknown (Raster models not-found as a null query field, not an HTTP 404).
+ */
+export async function resolveSlugToArtwork(slug: string): Promise<RasterArtworkSummary | null> {
+  const data = await rasterQuery<{
+    artworkBySlug: {
+      id: string;
+      title: string;
+      artists: ArtistFields[];
+    } | null;
+  }>(
+    `query ResolveSlug($slug: String!) {
+      artworkBySlug(slug: $slug) {
+        id
+        title
+        artists { id name slug }
+      }
+    }`,
+    { slug }
+  );
+
+  const artwork = data.artworkBySlug;
+  if (!artwork) {
+    return null;
+  }
+  return {
+    artworkId: artwork.id,
+    title: artwork.title,
+    artists: (artwork.artists ?? []).map(toRasterArtist),
+  };
+}
+
+/**
  * Resolve a wallet address to the Raster artist who claims it.
  *
  * The `address` query carries artist associations directly (the old REST
@@ -212,7 +262,16 @@ export async function listArtworkTokens(
   const data = await rasterQuery<{
     artwork: {
       tokens: {
-        nodes: Array<{ chainId: string; contractAddress: string | null; tokenId: string }>;
+        nodes: Array<{
+          chainId: string;
+          contractAddress: string | null;
+          tokenId: string;
+          media: {
+            contentUrl: string | null;
+            contentType: string | null;
+            previewType: string | null;
+          } | null;
+        }>;
         pageInfo: { hasNextPage: boolean; endCursor: string | null };
       };
     } | null;
@@ -220,7 +279,7 @@ export async function listArtworkTokens(
     `query ArtworkTokens($id: ID!, $first: Int, $after: String) {
       artwork(id: $id) {
         tokens(first: $first, after: $after) {
-          nodes { chainId contractAddress tokenId }
+          nodes { chainId contractAddress tokenId media { contentUrl contentType previewType } }
           pageInfo { hasNextPage endCursor }
         }
       }
@@ -244,6 +303,10 @@ export async function listArtworkTokens(
       chain,
       contractAddress: raw.contractAddress,
       tokenId: raw.tokenId,
+      mediaUrl: raw.media?.contentUrl ?? null,
+      // Prefer a real MIME (`contentType`) when Raster populates it; today it
+      // is usually empty, so fall back to the category-prefixed `previewType`.
+      mediaType: raw.media?.contentType || raw.media?.previewType || null,
     });
   }
 

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -12,7 +12,8 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { parseFindInput } from '../src/utilities/marketplace-url';
-import { parseLimitOption, decideActions } from '../src/commands/find';
+import { parseLimitOption, decideActions, buildRasterMediaItems } from '../src/commands/find';
+import type { BuildToken, ResolvedTarget } from '../src/commands/find';
 
 describe('parseFindInput', () => {
   test('Ethereum wallet address → address kind', () => {
@@ -286,6 +287,33 @@ describe('parseFindInput', () => {
     assert.ok(r.reason.includes('base'));
   });
 
+  test('Raster /artwork/{slug} URL → raster-artwork kind', () => {
+    const r = parseFindInput('https://raster.art/artwork/split-logic-by-ricky-retouch');
+    assert.equal(r?.kind, 'raster-artwork');
+    if (r?.kind !== 'raster-artwork') {
+      throw new Error('narrowing');
+    }
+    assert.equal(r.slug, 'split-logic-by-ricky-retouch');
+  });
+
+  test('Raster /artwork/{slug} URL with trailing slash + query → raster-artwork kind', () => {
+    const r = parseFindInput('https://raster.art/artwork/split-logic-by-ricky-retouch/?ref=x');
+    assert.equal(r?.kind, 'raster-artwork');
+    if (r?.kind !== 'raster-artwork') {
+      throw new Error('narrowing');
+    }
+    assert.equal(r.slug, 'split-logic-by-ricky-retouch');
+  });
+
+  test('Raster non-artwork URL → unsupported with /artwork/ hint', () => {
+    const r = parseFindInput('https://raster.art/explore');
+    assert.equal(r?.kind, 'unsupported');
+    if (r?.kind !== 'unsupported') {
+      throw new Error('narrowing');
+    }
+    assert.ok(r.reason.includes('/artwork/'));
+  });
+
   test('SuperRare /collection/{contract} URL → unsupported with specific message', () => {
     const r = parseFindInput(
       'https://superrare.com/collection/0x3e930455dcBf4bC69DE9926bDAF8ef782398786f'
@@ -432,5 +460,120 @@ describe('decideActions', () => {
   test('--yes --publish → [publish] (publish flag overrides default Play)', async () => {
     const actions = await decideActions({ yes: true, publish: true });
     assert.deepEqual(actions, ['publish']);
+  });
+});
+
+/**
+ * `buildRasterMediaItems` is the FF-indexer bypass: when the indexer resolves
+ * nothing for a Raster-minted series, items are built straight from each
+ * token's Raster `media.contentUrl` (off-chain provenance, Neort-style) so the
+ * playlist still builds and verifies. These assert the title/source/provenance
+ * shape, the drop-on-missing-media behavior, and — critically — that Raster's
+ * `mediaType` drives DP-1 timing so an extensionless IPFS video isn't
+ * misclassified as a static still. No network.
+ */
+describe('buildRasterMediaItems', () => {
+  const series: ResolvedTarget = {
+    kind: 'series',
+    summary: { artworkId: '2886465', title: 'Split Logic', artists: [] },
+  };
+
+  test('builds one off-chain item per token, titled "<Series> #<tokenId>"', () => {
+    const tokens: BuildToken[] = [
+      {
+        chain: 'ethereum',
+        contract: '0xabc',
+        tokenId: '1',
+        mediaUrl: 'https://media/1.mp4',
+        mediaType: 'video/mp4',
+      },
+      {
+        chain: 'ethereum',
+        contract: '0xabc',
+        tokenId: '94',
+        mediaUrl: 'https://media/94.mp4',
+        mediaType: 'video/mp4',
+      },
+    ];
+    const items = buildRasterMediaItems(tokens, series) as Array<{
+      title: string;
+      source: string;
+      provenance: { type: string; uri: string };
+    }>;
+    assert.equal(items.length, 2);
+    assert.equal(items[0].title, 'Split Logic #1');
+    assert.equal(items[0].source, 'https://media/1.mp4');
+    assert.equal(items[0].provenance.type, 'offChainURI');
+    assert.equal(items[0].provenance.uri, 'https://media/1.mp4');
+    assert.equal(items[1].title, 'Split Logic #94');
+  });
+
+  test('extensionless IPFS video (mediaType "video/2") gets no fixed duration, loops off', () => {
+    // The real-world Raster shape: contentUrl has no file extension and the
+    // only type signal is the category-prefixed previewType. Without the hint
+    // this video would be stamped a static duration and play as a freeze-frame.
+    const tokens: BuildToken[] = [
+      {
+        chain: 'ethereum',
+        contract: '0xabc',
+        tokenId: '1',
+        mediaUrl: 'https://ipfs.verse.works/ipfs/bafybeifi2e6h3katweqgx2wz',
+        mediaType: 'video/2',
+      },
+    ];
+    const items = buildRasterMediaItems(tokens, series) as Array<{
+      duration?: number;
+      display?: { loop?: boolean };
+    }>;
+    assert.equal(items[0].duration, undefined);
+    assert.equal(items[0].display?.loop, false);
+  });
+
+  test('extensionless still (mediaType "image/1") gets a fixed display duration', () => {
+    const tokens: BuildToken[] = [
+      {
+        chain: 'ethereum',
+        contract: '0xabc',
+        tokenId: '2',
+        mediaUrl: 'https://ipfs.verse.works/ipfs/bafybeiawsns62ftxpi3vffbn',
+        mediaType: 'image/1',
+      },
+    ];
+    const items = buildRasterMediaItems(tokens, series) as Array<{ duration?: number }>;
+    assert.equal(typeof items[0].duration, 'number');
+  });
+
+  test('drops tokens with no Raster media (nothing playable to point at)', () => {
+    const tokens: BuildToken[] = [
+      {
+        chain: 'ethereum',
+        contract: '0xabc',
+        tokenId: '1',
+        mediaUrl: 'https://media/1.mp4',
+        mediaType: 'video/mp4',
+      },
+      { chain: 'ethereum', contract: '0xabc', tokenId: '2', mediaUrl: null, mediaType: null },
+    ];
+    const items = buildRasterMediaItems(tokens, series);
+    assert.equal(items.length, 1);
+  });
+
+  test('single-token target (Raster did not index the series) falls back to "Token <id>"', () => {
+    const single: ResolvedTarget = {
+      kind: 'single',
+      coords: { chain: 'tezos', contract: 'KT1abc', tokenId: '7' },
+    };
+    const tokens: BuildToken[] = [
+      {
+        chain: 'tezos',
+        contract: 'KT1abc',
+        tokenId: '7',
+        mediaUrl: 'https://media/7.mp4',
+        mediaType: 'video/mp4',
+      },
+    ];
+    const items = buildRasterMediaItems(tokens, single) as Array<{ title: string }>;
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, 'Token 7');
   });
 });


### PR DESCRIPTION
## What

Adds first-class support for **Raster (raster.art)** artworks in `ff-cli find`, and makes Raster-minted series build reliably without `--skip-verify`.

Reported by Lucian while driving an Art Computer via the claw: a Raster URL wasn't recognized, and the raw coordinate stalled at the FF indexer — forcing a manual scrape + one-item DP-1 + `play --skip-verify` workaround.

## Why it was broken

Two independent issues (neither fixed by upgrading 1.3.1 → 1.5.0):

1. **`raster.art` URLs weren't a recognized input** — no host parser in `marketplace-url.ts`.
2. **Raster-minted tokens aren't reliably carried by the FF indexer** (`indexer.feralfile.com`, our own service). `find` resolved the series via Raster but then handed tokens to the indexer for DP-1 conversion, which could return nothing → hard failure. (In re-testing the repro coord now indexes fine, so this is largely a transient cold-cache condition — the fix makes it non-fatal.)

Plus a latent timing bug surfaced while fixing #2: Raster's `media.contentUrl` is an extensionless IPFS URL with empty `contentType`, so a video was misclassified as a static still and stamped a fixed duration.

## What this does

- Parse `raster.art/artwork/{slug}` → resolve via Raster `artworkBySlug`.
- Carry per-token `media.contentUrl` + a media-type hint on token enumeration.
- **FF-indexer bypass:** when the indexer returns nothing for a Raster-resolved target, build DP-1 items directly from Raster media (off-chain provenance, same shape as the Neort path) — signable and verifiable, no `--skip-verify`. The indexer is tried **first**, so tokens it can resolve keep their richer on-chain provenance (no regression to existing sources).
- Thread a media-type hint (`contentType || previewType`, e.g. `"video/2"`) into `buildUrlItem` so extensionless IPFS videos get correct DP-1 timing (natural length, `loop: false`) instead of playing as stills.
- Add `raster.art` to `find` help text and the supported-source list.

## Testing

- 8 new unit tests (parser cases + `buildRasterMediaItems` shape, drop-on-missing-media, and timing for `video/2` vs `image/1`). Full suite: **380 pass**.
- Live e2e against `api.raster.art` + FF infra:
  - `find "ethereum:0xf570…b5:95"` → resolves "Ricky Retouch — Split Logic", builds 20 items.
  - `find "https://raster.art/artwork/split-logic-by-ricky-retouch"` → resolves + builds.
  - **Indexer forced to fail** → fallback builds 3 items from Raster IPFS videos, off-chain provenance, validates as DP-1, video items carry no fixed duration.

## Known limitations (match current behavior — not regressions)

- **Partial-index drops:** if the indexer returns *some* tokens but drops the Raster-only ones, those are still dropped (no per-token fallback). The all-dropped case now recovers; this is a strict improvement.
- **Exotic media timing:** an interactive/HTML work whose `previewType` isn't `video/*` / `audio/*` gets default-duration static treatment — same as ff-cli's existing fallback for unknown types.

## Follow-ups (tracked separately)

- Ask Raster to populate `media.contentType` with a real MIME (lets us drop the `previewType` workaround) + document the `previewType` enum.
- Consider "Raster-first for Raster-resolved series" (reconstruct on-chain provenance from coords we hold) if Raster becomes a primary path rather than a fallback.
