### PR TITLE
feat: handle device command-storm rate limiting (HTTP 429)

### DIFF
--- a/src/utilities/ff1-device.ts
+++ b/src/utilities/ff1-device.ts
@@ -9,6 +9,10 @@ import { assertFF1CommandCompatibility, resolveConfiguredDevice } from './ff1-co
 
 const SEND_RETRY_ATTEMPTS = 3;
 const SEND_RETRY_BASE_DELAY_MS = 750;
+const RATE_LIMIT_STATUS = 429;
+// Cap how long a device-supplied Retry-After can stall the CLI, so a buggy or
+// hostile device cannot pin a command for minutes/hours.
+const MAX_RETRY_DELAY_MS = 30_000;
 
 interface SendPlaylistParams {
   playlist: Playlist;
@@ -85,6 +89,40 @@ export function isTransientDeviceNetworkError(error: unknown): boolean {
       : undefined;
 
   return Boolean(causeCode && networkCodes.has(causeCode));
+}
+
+/**
+ * parseRetryAfterMs converts an HTTP `Retry-After` header into milliseconds.
+ *
+ * Supports both forms from RFC 7231: a delta-seconds integer (e.g. "5") and an
+ * HTTP-date (e.g. "Wed, 21 Oct 2025 07:28:00 GMT"). Returns undefined when the
+ * header is absent or unparseable, so callers can fall back to their own
+ * backoff. A past date clamps to 0 (retry immediately).
+ *
+ * @param {string | null | undefined} headerValue - Raw Retry-After header value
+ * @returns {number | undefined} Delay in milliseconds, or undefined if unknown
+ */
+export function parseRetryAfterMs(headerValue: string | null | undefined): number | undefined {
+  if (!headerValue) {
+    return undefined;
+  }
+
+  const trimmed = headerValue.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  // A valid HTTP-date always contains letters (month/day names, or the ISO
+  // 'T'/'Z'). Requiring one rejects bare numeric junk (e.g. "-5", "5.5") that
+  // Date.parse would otherwise misinterpret as a date.
+  if (/[a-zA-Z]/.test(trimmed)) {
+    const dateMs = Date.parse(trimmed);
+    if (!Number.isNaN(dateMs)) {
+      return Math.max(0, dateMs - Date.now());
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -187,6 +225,23 @@ export async function sendPlaylistToDevice({
           headers,
           body: JSON.stringify(requestBody),
         });
+
+        // The device sheds bursts of commands with HTTP 429 to protect itself.
+        // Treat it as transient: honor Retry-After when present, otherwise back
+        // off, and retry within the bounded attempt budget.
+        if (response.status === RATE_LIMIT_STATUS && attempt < SEND_RETRY_ATTEMPTS) {
+          const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
+          const retryDelay = Math.min(
+            retryAfterMs ?? SEND_RETRY_BASE_DELAY_MS * attempt,
+            MAX_RETRY_DELAY_MS
+          );
+          logger.warn(
+            `Device rate-limited the command (attempt ${attempt}/${SEND_RETRY_ATTEMPTS}); retrying in ${retryDelay}ms`
+          );
+          response = null;
+          await waitForRetry(retryDelay);
+          continue;
+        }
         break;
       } catch (error) {
         const shouldRetry = attempt < SEND_RETRY_ATTEMPTS && isTransientDeviceNetworkError(error);
@@ -219,6 +274,17 @@ export async function sendPlaylistToDevice({
       const errorText = await response.text();
       logger.error(`Failed to cast to device: ${response.status} ${response.statusText}`);
       logger.debug(`Error details: ${errorText}`);
+
+      if (response.status === RATE_LIMIT_STATUS) {
+        const deviceLabel = device.name || device.host;
+        return {
+          success: false,
+          error: `Device "${deviceLabel}" is busy and rate-limited the command`,
+          details:
+            'The Art Computer is shedding a burst of commands to protect itself. ' +
+            'Wait a few seconds and try again.',
+        };
+      }
 
       return {
         success: false,

--- a/tests/ff1-device-rate-limit.test.ts
+++ b/tests/ff1-device-rate-limit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRetryAfterMs } from '../src/utilities/ff1-device';
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds into milliseconds', () => {
+    assert.equal(parseRetryAfterMs('5'), 5000);
+    assert.equal(parseRetryAfterMs(' 0 '), 0);
+    assert.equal(parseRetryAfterMs('120'), 120000);
+  });
+
+  it('parses an HTTP-date into a non-negative delay', () => {
+    const future = new Date(Date.now() + 10000).toUTCString();
+    const ms = parseRetryAfterMs(future);
+    assert.ok(ms !== undefined);
+    // Allow scheduling slack: should be within a couple seconds of 10s.
+    assert.ok(ms! > 7000 && ms! <= 11000, `unexpected delay ${ms}`);
+  });
+
+  it('clamps a past HTTP-date to 0 (retry immediately)', () => {
+    const past = new Date(Date.now() - 60000).toUTCString();
+    assert.equal(parseRetryAfterMs(past), 0);
+  });
+
+  it('returns undefined for absent or unparseable values', () => {
+    assert.equal(parseRetryAfterMs(null), undefined);
+    assert.equal(parseRetryAfterMs(undefined), undefined);
+    assert.equal(parseRetryAfterMs(''), undefined);
+    assert.equal(parseRetryAfterMs('soon'), undefined);
+    assert.equal(parseRetryAfterMs('-5'), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Client-side companion to the FF1 device-side command-storm protection (feral-file/ffos-user#208). The device now sheds command floods with **HTTP 429**; this CLI previously treated 429 as a permanent error and surfaced a cryptic `Device returned error 429: Too Many Requests` with no recovery path.

## Changes
- `parseRetryAfterMs()` — parses the `Retry-After` header (RFC 7231 delta-seconds or HTTP-date); returns `undefined` for absent/garbage values so the caller falls back to its own backoff. Capped via `MAX_RETRY_DELAY_MS` (30s) so a buggy/hostile device can't stall the CLI.
- In the existing bounded send-retry loop, a **429 is now treated as transient**: honor `Retry-After` when present, otherwise linear backoff, and retry within the existing 3-attempt budget.
- An exhausted 429 returns a clear, actionable message: *"Device … is busy and rate-limited the command … wait a few seconds and try again."*
- Unit tests for `parseRetryAfterMs` (delta-seconds, HTTP-date, past-date clamp, unparseable input).

## Verification
- `npm run typecheck` clean; `eslint` + `prettier` clean on changed files; new `parseRetryAfterMs` tests pass (4/4).
- Note: this repo has ~34 pre-existing test failures on `main` unrelated to this change.

## Reviewer note
A separate review flagged (LOW) that without jitter many CLIs could retry in lockstep — acceptable for a single-user CLI over a 3-attempt budget; left as a potential future tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)