### PR TITLE
Post-2.0 cleanup: drop legacy config migration; unify play/find cast path

### DIFF
--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -22,7 +22,7 @@ import {
   formatSummaryLine,
 } from '../utilities/raster-client';
 import type { RasterArtworkSummary, RasterArtworkRow } from '../utilities/raster-client';
-import { sendPlaylistToDevice } from '../utilities/ff1-device';
+import { castPlaylist } from '../utilities/playlist-cast';
 
 // nft-indexer + playlist-builder are still CommonJS; require keeps interop simple.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -544,20 +544,22 @@ async function doPlay(
   deviceName: string | undefined,
   skipVerify: boolean
 ): Promise<void> {
-  // Match `ff-cli play`'s verification gate: signed playlists are verified
-  // before device delivery; the same surface that play surfaces failures.
-  // `buildDP1Playlist` signs when a playlist private key is configured and
-  // silently continues unsigned otherwise — so when no key is set, the user
-  // sees an actionable error here instead of an unverifiable playlist on
-  // the wall.
+  // Same verify → send gate `ff-cli play` uses, via the shared castPlaylist
+  // helper. `find`'s playlists are already signed by buildDP1Playlist (when a
+  // key is configured), so no signing is requested here — an unsigned one
+  // fails the verify gate with an actionable message instead of reaching the
+  // wall unverifiable.
   if (!skipVerify) {
-    const { verifyPlaylist } = await import('../utilities/playlist-verifier');
     console.log(chalk.cyan('Verify playlist'));
-    const verifyResult = await verifyPlaylist(playlist);
-    if (!verifyResult.valid) {
-      console.error(chalk.red('Playlist verification failed:'), verifyResult.error);
-      if (verifyResult.details && verifyResult.details.length > 0) {
-        for (const d of verifyResult.details) {
+  }
+
+  const result = await castPlaylist(playlist, { deviceName, skipVerify });
+
+  if (!result.success) {
+    if (result.stage === 'verify') {
+      console.error(chalk.red('Playlist verification failed:'), result.error);
+      if (result.details && result.details.length > 0) {
+        for (const d of result.details) {
           console.error(chalk.dim(`  ${d.path}: ${d.message}`));
         }
       }
@@ -567,29 +569,28 @@ async function doPlay(
             'or pass --skip-verify to bypass.'
         )
       );
-      process.exitCode = 1;
-      return;
+    } else {
+      console.error(chalk.red('Play failed:'), result.error);
+      if (result.deviceDetails) {
+        console.error(chalk.dim(`  Details: ${result.deviceDetails}`));
+      }
     }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.verified) {
     console.log(chalk.green('✓ Verified\n'));
   }
   console.log(chalk.blue('Play on FF1'));
-  const result = await sendPlaylistToDevice({ playlist, deviceName });
-  if (result.success) {
-    console.log(chalk.green('✓ Playing'));
-    if (result.deviceName) {
-      console.log(chalk.dim(`  Device: ${result.deviceName}`));
-    }
-    if (result.device) {
-      console.log(chalk.dim(`  Host: ${result.device}`));
-    }
-    console.log();
-    return;
+  console.log(chalk.green('✓ Playing'));
+  if (result.deviceName) {
+    console.log(chalk.dim(`  Device: ${result.deviceName}`));
   }
-  console.error(chalk.red('Play failed:'), result.error);
-  if (result.details) {
-    console.error(chalk.dim(`  Details: ${result.details}`));
+  if (result.device) {
+    console.log(chalk.dim(`  Host: ${result.device}`));
   }
-  process.exitCode = 1;
+  console.log();
 }
 
 async function doPublish(

--- a/src/commands/helpers/config-files.ts
+++ b/src/commands/helpers/config-files.ts
@@ -13,7 +13,7 @@ export async function readConfigFile(configPath: string): Promise<Config> {
 
 /**
  * Locate an existing config.json. Local (`./config.json`) wins over user
- * (`~/.config/ff1/config.json`). Returns null when neither exists.
+ * (`~/.config/ff-cli/config.json`). Returns null when neither exists.
  */
 export async function resolveExistingConfigPath(): Promise<string | null> {
   const { localPath, userPath } = getConfigPaths();

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -3,16 +3,11 @@ import chalk from 'chalk';
 import { getConfig } from '../config';
 import { isPlaylistSourceUrl, resolvePlaySource } from '../utilities/playlist-source';
 import { parseFindInput } from '../utilities/marketplace-url';
+import { castPlaylist } from '../utilities/playlist-cast';
 import {
   printPlaylistSourceLoadFailure,
   printPlaylistVerificationFailure,
 } from './helpers/playlist-display';
-
-// ff1-device is still CommonJS; require keeps the interop simple.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { sendPlaylistToDevice } = require('../utilities/ff1-device');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { signPlaylist } = require('../utilities/playlist-signer');
 
 /**
  * Human label for a discovery input that `play` cannot cast directly.
@@ -102,93 +97,50 @@ export const playCommand = new Command('play')
 
       console.log(chalk.blue('\nPlay on FF1\n'));
 
-      if (!options.skipVerify) {
-        const playlistConfig = config.playlist;
-        const privateKey = playlistConfig?.privateKey || process.env.PLAYLIST_PRIVATE_KEY;
-        const { verifyPlaylist } = await import('../utilities/playlist-verifier');
-
-        if (isPlaylistSource) {
-          console.log(chalk.cyan(`Verify playlist (${sourceLabel})`));
-        }
-
-        const verifyResult =
-          resolved.kind === 'media'
-            ? await (async () => {
-                try {
-                  if (!privateKey) {
-                    return {
-                      valid: false,
-                      error:
-                        'Cannot sign playlist for playback: no playlist signing key is configured',
-                    };
-                  }
-
-                  const signature = await signPlaylist(resolved.playlist, privateKey);
-                  const signedPlaylist = {
-                    ...resolved.playlist,
-                    signature: undefined,
-                    signatures: [signature],
-                  };
-                  const signedVerification = await verifyPlaylist(signedPlaylist);
-                  if (signedVerification.valid) {
-                    resolved.playlist = signedPlaylist as typeof resolved.playlist;
-                    return { valid: true, playlist: signedPlaylist };
-                  }
-
-                  return {
-                    valid: false,
-                    error: signedVerification.error,
-                    details: signedVerification.details,
-                  };
-                } catch (error) {
-                  return {
-                    valid: false,
-                    error: `Failed to sign playlist for playback: ${(error as Error).message}`,
-                  };
-                }
-              })()
-            : await verifyPlaylist(resolved.playlist);
-
-        if (!verifyResult.valid) {
-          printPlaylistVerificationFailure(
-            {
-              valid: false,
-              error: verifyResult.error,
-              details: verifyResult.details,
-            },
-            isPlaylistSource ? `source: ${sourceLabel}` : undefined
-          );
-          process.exit(1);
-        }
-
-        if (resolved.kind === 'media') {
-          console.log(chalk.green('✓ Signed and verified\n'));
-        } else if (isPlaylistSource) {
-          console.log(chalk.green('✓ Verified\n'));
-        }
+      if (!options.skipVerify && isPlaylistSource) {
+        console.log(chalk.cyan(`Verify playlist (${sourceLabel})`));
       }
 
-      const result = await sendPlaylistToDevice({
-        playlist: resolved.playlist,
+      // A direct media/web URL is wrapped in an unsigned single-item playlist,
+      // so it must be signed before the verify gate; a loaded playlist is sent
+      // as-is. castPlaylist owns the sign → verify → send sequence.
+      const privateKey = config.playlist?.privateKey || process.env.PLAYLIST_PRIVATE_KEY;
+      const result = await castPlaylist(resolved.playlist, {
         deviceName: options.device,
+        skipVerify: options.skipVerify,
+        requireSignature: resolved.kind === 'media',
+        signingKey: privateKey,
       });
 
-      if (result.success) {
-        console.log(chalk.green('✓ Playing'));
-        if (result.deviceName) {
-          console.log(chalk.dim(`  Device: ${result.deviceName}`));
-        }
-        if (result.device) {
-          console.log(chalk.dim(`  Host: ${result.device}`));
-        }
-        console.log();
-      } else {
-        console.error(chalk.red('\nPlay failed:'), result.error);
-        if (result.details) {
-          console.error(chalk.dim(`  Details: ${result.details}`));
+      if (!result.success) {
+        if (result.stage === 'verify') {
+          printPlaylistVerificationFailure(
+            { valid: false, error: result.error, details: result.details },
+            isPlaylistSource ? `source: ${sourceLabel}` : undefined
+          );
+        } else if (result.stage === 'sign') {
+          console.error(chalk.red(`\n${result.error}`));
+        } else {
+          console.error(chalk.red('\nPlay failed:'), result.error);
+          if (result.deviceDetails) {
+            console.error(chalk.dim(`  Details: ${result.deviceDetails}`));
+          }
         }
         process.exit(1);
       }
+
+      if (result.verified) {
+        console.log(chalk.green(result.signed ? '✓ Signed and verified\n' : '✓ Verified\n'));
+      }
+
+      console.log(chalk.green('✓ Playing'));
+      if (result.deviceName) {
+        console.log(chalk.dim(`  Device: ${result.deviceName}`));
+      }
+      if (result.device) {
+        console.log(chalk.dim(`  Host: ${result.device}`));
+      }
+      console.log();
     } catch (error) {
       if (isPlaylistSourceUrl(source)) {
         printPlaylistSourceLoadFailure(source, error as Error);

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,43 +15,10 @@ import {
 } from './utilities/playlist-signing-role';
 import { configuredFF1Devices } from './utilities/config-placeholders';
 
-// One-shot legacy config migration: copy `$XDG_CONFIG_HOME/ff1/config.json` to
-// `$XDG_CONFIG_HOME/ff-cli/config.json` on first read after upgrading from
-// `ff1-cli`. The check is cheap (two fs.existsSync calls) and the
-// `migrationChecked` flag keeps it to one attempt per process.
-//
-// Remove this block after a release cycle once telemetry suggests no remaining
-// users still have only the legacy path populated.
-let migrationChecked = false;
-
-function migrateLegacyConfigIfNeeded(newUserPath: string): void {
-  if (migrationChecked) {
-    return;
-  }
-  migrationChecked = true;
-
-  const configBase = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
-  const legacyUserPath = path.join(configBase, 'ff1', 'config.json');
-
-  if (!fs.existsSync(legacyUserPath) || fs.existsSync(newUserPath)) {
-    return;
-  }
-
-  try {
-    fs.mkdirSync(path.dirname(newUserPath), { recursive: true });
-    fs.copyFileSync(legacyUserPath, newUserPath);
-    console.log(`Migrated config from ${legacyUserPath} to ${newUserPath}`);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Warning: Failed to migrate legacy config from ${legacyUserPath}: ${message}`);
-  }
-}
-
 export function getConfigPaths(): { localPath: string; userPath: string } {
   const localPath = path.join(process.cwd(), 'config.json');
   const configBase = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
   const userPath = path.join(configBase, 'ff-cli', 'config.json');
-  migrateLegacyConfigIfNeeded(userPath);
   return { localPath, userPath };
 }
 

--- a/src/utilities/playlist-cast.ts
+++ b/src/utilities/playlist-cast.ts
@@ -1,0 +1,139 @@
+import type { Playlist } from '../types';
+
+// playlist-signer and ff1-device are still CommonJS; require keeps interop simple.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { signPlaylist } = require('./playlist-signer');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { sendPlaylistToDevice } = require('./ff1-device');
+
+export type CastStage = 'sign' | 'verify' | 'send';
+
+export interface CastPlaylistOptions {
+  /** Target device name; falls back to the first configured device when omitted. */
+  deviceName?: string;
+  /** Bypass the sign + verify gate entirely (the `--skip-verify` escape hatch). */
+  skipVerify?: boolean;
+  /**
+   * Sign the playlist before verifying. Used for the synthesized-media
+   * fallback, whose single-item playlist is unsigned at build time. When set
+   * but `signingKey` is missing, the cast fails closed at the `sign` stage
+   * rather than delivering an unverifiable playlist.
+   */
+  requireSignature?: boolean;
+  /** Ed25519 key (base64 or hex) used when `requireSignature` is set. */
+  signingKey?: string | null;
+}
+
+export interface CastPlaylistResult {
+  success: boolean;
+  /** The playlist actually delivered — signed in place when `requireSignature`. */
+  playlist: Playlist;
+  /** Whether this call signed the playlist (drives "Signed and verified" vs "Verified"). */
+  signed: boolean;
+  /** Whether the verify gate ran and passed (false when skipped). */
+  verified: boolean;
+  /** Where it failed, when `success` is false. */
+  stage?: CastStage;
+  deviceName?: string;
+  device?: string;
+  error?: string;
+  /** Structured DP-1 validation errors (verify-stage failures). */
+  details?: Array<{ path: string; message: string }>;
+  /** Free-text device transport detail (send-stage failures). */
+  deviceDetails?: string;
+}
+
+/**
+ * Shared "(sign →) verify → send to device" sequence used by `play` and
+ * `find --play`.
+ *
+ * This is the single source of truth for getting a playlist onto an FF1: the
+ * verification gate, the synthesized-media auto-sign (rebuilding the
+ * `signatures[]` envelope), and the device transport. Callers own their
+ * console output and map the returned `stage`/`error` to their own messages —
+ * keeping delivery behavior consistent without coupling the two commands'
+ * UX. Previously this logic was duplicated across `play`, `find`, and the
+ * (now-removed) chat send path, and drifted between them.
+ */
+export async function castPlaylist(
+  playlist: Playlist,
+  options: CastPlaylistOptions = {}
+): Promise<CastPlaylistResult> {
+  let current = playlist;
+  let signed = false;
+  let verified = false;
+
+  if (!options.skipVerify) {
+    if (options.requireSignature) {
+      if (!options.signingKey) {
+        return {
+          success: false,
+          playlist: current,
+          signed: false,
+          verified: false,
+          stage: 'sign',
+          error: 'Cannot sign playlist for playback: no playlist signing key is configured',
+        };
+      }
+      try {
+        const signature = await signPlaylist(current, options.signingKey);
+        current = {
+          ...current,
+          signature: undefined,
+          signatures: [signature],
+        } as Playlist;
+        signed = true;
+      } catch (error) {
+        return {
+          success: false,
+          playlist: current,
+          signed: false,
+          verified: false,
+          stage: 'sign',
+          error: `Failed to sign playlist for playback: ${(error as Error).message}`,
+        };
+      }
+    }
+
+    const { verifyPlaylist } = await import('./playlist-verifier');
+    const verifyResult = await verifyPlaylist(current);
+    if (!verifyResult.valid) {
+      return {
+        success: false,
+        playlist: current,
+        signed,
+        verified: false,
+        stage: 'verify',
+        error: verifyResult.error,
+        details: verifyResult.details,
+      };
+    }
+    verified = true;
+  }
+
+  const sendResult = await sendPlaylistToDevice({
+    playlist: current,
+    deviceName: options.deviceName,
+  });
+
+  if (sendResult.success) {
+    return {
+      success: true,
+      playlist: current,
+      signed,
+      verified,
+      deviceName: sendResult.deviceName,
+      device: sendResult.device,
+    };
+  }
+
+  return {
+    success: false,
+    playlist: current,
+    signed,
+    verified,
+    stage: 'send',
+    error: sendResult.error,
+    deviceDetails: sendResult.details,
+  };
+}


### PR DESCRIPTION
Two cleanups surfaced while reading the code during the 2.0 work.

## 1. Drop the legacy `ff1` → `ff-cli` config migration
`config.ts` ran a one-shot copy of `~/.config/ff1/config.json` → the `ff-cli` path on every config read. Its own comment said *"remove after a release cycle"* — a major version (2.x) is the natural moment. Also fixes a stale `ff1` path in a `config-files` docstring.

**Impact:** anyone still on the pre-rename `ff1-cli` config path who hasn't launched since would re-run `ff-cli setup`. Low.

## 2. Extract a shared `castPlaylist` (sign → verify → send)
The "(sign if synthesized-media) → verify → send to device" sequence was implemented twice — in `play` and in `find`'s `doPlay` — and was a third copy in the now-removed chat path. It had drifted, and we had to reason about it in two places during the playback-timing fixes.

New `src/utilities/playlist-cast.ts#castPlaylist` is the single source of truth: verify gate, the synthesized-media auto-sign that rebuilds the `signatures[]` envelope, and device transport. It returns a structured `{ success, stage, signed, verified, error, details, deviceDetails }`; each command keeps its own console output and maps the result to its messages, so **observable behavior is unchanged** — the `play` delivery-signing and `--skip-verify` e2e tests pass as-is.

## Verification
`npm run verify` green — 370 tests, lint/format clean. No version bump (internal cleanup; rides the next release).