### PR TITLE
fix: repair prebuilt install + agent-flow rough edges (customer report)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ ff-cli is a set of deterministic commands for building DP-1–conformant playlis
 npm i -g @feralfile/cli
 ```
 
+This is the recommended path and the most reliable for the agent workflow — it installs a complete package (including `config.json.example` and the bundled `dp1-js`). Requires Node.js 22+.
+
 ## Install (curl)
 
 ```bash
 curl -fsSL https://feralfile.com/ff-cli-install | bash
 ```
 
-Installs a prebuilt binary for macOS/Linux (no Node.js required).
+Installs a prebuilt binary for macOS/Linux. Node.js 22+ must still be on your PATH (the bundle runs under `node`). If a command fails right after install, prefer the npm install above.
 
 ## One-off Usage (npx)
 
@@ -41,6 +43,23 @@ If you need manual config actions instead of guided setup:
 ff-cli config init
 ff-cli config validate
 ```
+
+### Non-interactive setup (agents / CI)
+
+`ff-cli setup` is fully scriptable — no TTY required. It runs non-interactively when stdin is not a terminal, or when you pass `-y/--non-interactive`, and takes flags for every step:
+
+```bash
+# Generate a signing key and register a device in one shot, no prompts
+ff-cli setup --non-interactive \
+  --generate-key \
+  --device-host http://192.168.1.50:1111 \
+  --device-name "Living Room"
+
+# Or supply your own key (base64 PKCS#8 DER, 32-byte seed as hex/base64, or PEM)
+ff-cli setup -y --key "<private-key>" --role agent
+```
+
+Device pairing is also scriptable on its own: `ff-cli device add --host http://<ip>:1111 --name <name>` skips mDNS discovery entirely.
 
 ## Find an artwork
 

--- a/config.json.example
+++ b/config.json.example
@@ -15,7 +15,7 @@
     }
   ],
   "playlist": {
-    "privateKey": "YOUR_ED25519_PRIVATE_KEY_BASE64_OR_HEX",
+    "privateKey": "YOUR_ED25519_PRIVATE_KEY__base64_PKCS8_DER_recommended__or_32byte_raw_seed_as_hex_or_base64__run_ff-cli_setup_to_generate",
     "role": "agent"
   },
   "ff1Devices": {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,30 +38,37 @@ Used for signing DP‑1 playlists.
 
 - `playlist.privateKey` (string, Ed25519 private key in hex or base64): Used by the `sign` command to create DP-1 v1.1.0 multi-signatures. The `verify` command may derive the matching public key from this value (or `PLAYLIST_PRIVATE_KEY`) when you omit `--public-key`; **dp1-js applies that derived key only when verifying legacy flat `signature` strings**, not when checking `signatures[]` envelopes. If that derivation fails, `verify` prints a warning on stderr and continues without derived key material. The derived public key is emitted as PEM so Node can decode it without ambiguity. Hex may include or omit the `0x` prefix. You can also set this via `PLAYLIST_PRIVATE_KEY` in `.env`. `play` verifies playlists before delivery and only auto-signs the synthesized media URL fallback when signing is configured. `play` and `publish` verify before delivery or upload and reject unsigned or broken playlists.
 
-  **Signing and key encoding:** Signing paths (`sign`, deterministic `build` when configured, and `-k/--key` overrides) pass the private key string through to **`dp1-js`** (`SignMultiEd25519`) without an extra decoding step in ff-cli. `dp1-js` recognizes **hex** (optional `0x`) or **base64** encodings of the PKCS#8 DER blob produced by the OpenSSL examples below, then loads the key for Ed25519. Use those formats; ff-cli does not add a separate normalizer ahead of the library.
+  **Signing and key encoding:** Signing paths (`sign`, deterministic `build` when configured, and `-k/--key` overrides) accept the private key in any of these encodings:
+
+  - **base64 PKCS#8 DER** — recommended; what `ff-cli setup` generates.
+  - **32-byte raw Ed25519 seed** as **hex** (optional `0x`) or **base64**.
+  - **PEM** (`-----BEGIN PRIVATE KEY-----`).
+  - **PKCS#8 DER as hex**.
+
+  ff-cli normalizes whichever form you supply to base64 PKCS#8 DER before handing it to **`dp1-js`** (`SignMultiEd25519`). A malformed key fails with an actionable message (e.g. _"Invalid Ed25519 signing key … run `ff-cli setup` to generate one"_) instead of dp1-js's cryptic OpenSSL ASN.1 error (`header too long` / `wrong tag`).
 
 - `playlist.role` (string): DP-1 signing role that travels with the private key. Defaults to `agent` if omitted. You can also set this via `PLAYLIST_ROLE` in `.env`. Guided `ff-cli setup`, `config validate`, and `sign --role` only accept the usual DP-1 signing roles (`agent`, `feed`, `curator`, `institution`, `licensor`).
 
 ### Generate an Ed25519 private key
 
-You can generate a key locally. The CLI accepts either base64 (preferred) or hex
+The simplest path is `ff-cli setup`, which generates a key for you (base64 PKCS#8 DER) and writes it to your config. To generate one yourself:
 
-OpenSSL (recommended):
+OpenSSL (recommended — produces a PKCS#8 DER key):
 
 ```bash
-# Base64 (preferred)
+# Base64 PKCS#8 DER (recommended)
 openssl genpkey -algorithm ED25519 -outform DER | base64 | tr -d '\n'
 
-# Hex (alternative)
+# Hex of the same PKCS#8 DER (alternative)
 openssl genpkey -algorithm ED25519 -outform DER | xxd -p -c 256
 ```
 
-Paste either value into `playlist.privateKey`:
+Paste the value into `playlist.privateKey`. Any of these are accepted:
 
-- Hex example (either is valid):
-  - `0xabc123...` (with prefix)
-  - `abc123...` (without prefix)
-- Base64 example: `uQd9m8S...==`
+- **base64 PKCS#8 DER** (recommended): `MC4CAQAwBQYDK2Vw...`
+- **32-byte raw seed** as hex (`0x`-prefixed or not) or base64 — e.g. the bare seed, not the full PKCS#8 blob.
+- **PEM**: a `-----BEGIN PRIVATE KEY-----` block.
+- **PKCS#8 DER as hex**.
 
 If you need a different role, set `playlist.role` to one of the DP-1 signing roles such as `agent`, `feed`, `curator`, `institution`, or `licensor`. The CLI rejects any other string before it reaches `dp1-js`.
 
@@ -114,6 +121,12 @@ Configure devices you want to play content on.
 
 During `ff-cli setup`, the CLI will attempt local discovery via mDNS (`_ff1._tcp`). If devices are found, you can pick one and the host will be filled in automatically. If discovery returns nothing, setup falls back to manual entry.
 
+> **mDNS is best-effort.** It frequently does not cross subnets — a common case with mesh routers (e.g. eero) that put wired and Wi-Fi clients on different `/24`s. If discovery comes up empty even though the device is reachable by IP, skip it entirely and add the device directly:
+>
+> ```bash
+> ff-cli device add --host http://<device-ip>:1111 --name <name>
+> ```
+
 You can also manage devices independently with:
 
 - `ff-cli device add` – Add a device interactively (with mDNS discovery), or non-interactively with `--host` and `--name`.
@@ -127,6 +140,28 @@ Selection rules when sending:
 
 - If you omit `-d`, the first configured device is used.
 - If you pass `-d <name>`, the CLI matches the device by `name` (exact match). If not found, you’ll see an error listing available devices.
+
+Device cast contract:
+
+The device exposes a single HTTP endpoint, `POST http://<device>:1111/api/cast`. `ff-cli play` casts a DP-1 playlist with:
+
+```jsonc
+POST http://<device>:1111/api/cast
+Content-Type: application/json
+// API-KEY: <optional, only if the device requires one>
+
+{
+  "command": "displayPlaylist",
+  "request": {
+    "dp1_call": { /* the full signed DP-1 playlist object */ },
+    "intent": { "action": "now_display" }
+  }
+}
+```
+
+The `intent` field is **required** — without it the device returns `{"message":{"ok":false}}` with no further explanation. `dp1_call` may be the playlist inline (as above) or a hosted playlist URL string; ff-cli sends the resolved playlist object.
+
+On the first cast after boot the device may return an empty body. ff-cli retries this automatically and, if it persists, reports a clear "accepted the request but returned no usable response" error rather than crashing on a JSON parse.
 
 Compatibility checks:
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -261,6 +261,8 @@ npm run dev -- play "https://example.com/video.mp4"
 npm run dev -- play playlist.json --skip-verify
 ```
 
+> **No feed server is required to cast.** A device can play any static, signed DP-1 playlist hosted at a public URL — sign it (`sign`), upload the JSON anywhere that serves it over HTTPS (S3, Supabase Storage, a static host, etc.), then `ff-cli play "<url>"`. The DP-1 Feed server ([Publish to Feed Server](#publish-to-feed-server) below) adds discovery and curation, but is optional for simply playing your own playlists.
+
 ## Publish to Feed Server
 
 Publish validated playlists to a DP-1 feed server for sharing and discovery.

--- a/scripts/release/build-asset.sh
+++ b/scripts/release/build-asset.sh
@@ -54,11 +54,28 @@ mkdir -p "$PACKAGE_DIR/bin" "$PACKAGE_DIR/lib"
 cp "$ROOT_DIR/dist/ff-cli.js" "$PACKAGE_DIR/lib/ff-cli.js"
 cp "$ROOT_DIR/package.json" "$PACKAGE_DIR/package.json"
 cp "$ROOT_DIR/LICENSE" "$PACKAGE_DIR/LICENSE"
+# Ship the sample config alongside the bundle so `ff-cli config init` / `setup`
+# can seed a config. The installer extracts this to the package root, which the
+# CLI resolves via a `<bundle>/lib/../config.json.example` lookup candidate.
+cp "$ROOT_DIR/config.json.example" "$PACKAGE_DIR/config.json.example"
 
 cat > "$PACKAGE_DIR/bin/ff-cli" <<'EOF'
 #!/usr/bin/env bash
 set -e
-BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Resolve the launcher through any symlinks before computing the package dir.
+# The installer symlinks ~/.local/bin/ff-cli -> ~/.local/ff-cli/bin/ff-cli, and
+# without this resolution "$0"'s dir would be ~/.local/bin, making the wrapper
+# look for ~/.local/lib/ff-cli.js (wrong) instead of the real lib/ next to it.
+SOURCE="${BASH_SOURCE[0]:-$0}"
+while [ -h "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  case "$SOURCE" in
+    /*) ;;
+    *) SOURCE="$DIR/$SOURCE" ;;
+  esac
+done
+BASE_DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
 APP="$BASE_DIR/lib/ff-cli.js"
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js 22+ is required. Install Node.js, then run this command again."

--- a/skills/ff-control/SKILL.md
+++ b/skills/ff-control/SKILL.md
@@ -14,6 +14,14 @@ Context:
 Keep it simple. Prefer deletion over added process.
 Do not invent new requirements.
 
+Bootstrap (only if not yet installed/configured — skip when `ff-cli status` already works):
+- Install (most reliable): `npm i -g @feralfile/cli` (needs Node.js 22+).
+- Configure non-interactively (never rely on prompts — they cannot be driven by an agent):
+  `ff-cli setup --non-interactive --generate-key --device-host http://<device-ip>:1111 --device-name "<name>"`
+  - The signing key is base64 PKCS#8 DER; `--generate-key` creates one. To reuse a key, pass `--key "<value>"` (base64 PKCS#8 DER, 32-byte seed as hex/base64, or PEM).
+  - Skip mDNS discovery entirely — it is unreliable across subnets. Always pass `--device-host`. Add more devices with `ff-cli device add --host http://<ip>:1111 --name "<name>"`.
+- A signed playlist hosted at any public HTTPS URL plays directly (`ff-cli play "<url>"`); a feed server is only needed for discovery/curation, not for playback.
+
 Flow:
 1) ff-cli status
 2) ff-cli config validate

--- a/src/commands/helpers/device-discovery.ts
+++ b/src/commands/helpers/device-discovery.ts
@@ -35,6 +35,12 @@ export async function discoverAndSelectDevice(
       ? discoveryResult.error
       : `${discoveryResult.error}.`;
     console.log(chalk.dim(`mDNS discovery failed: ${errorMessage} Continuing with manual entry.`));
+    console.log(
+      chalk.dim(
+        '  Tip: you can skip discovery entirely with ' +
+          'ff-cli device add --host http://<device-ip>:1111 --name <name>'
+      )
+    );
   } else if (discoveryResult.error) {
     console.log(chalk.dim(`mDNS discovery warning: ${discoveryResult.error}`));
   }
@@ -132,6 +138,15 @@ export async function discoverAndSelectDevice(
     }
   } else if (!discoveryResult.error) {
     console.log(chalk.dim('No FF1 devices found via mDNS. Continuing with manual entry.'));
+    // mDNS is best-effort and frequently fails across subnets (a common setup
+    // with mesh routers that put wired and Wi-Fi clients on different /24s).
+    // Point users at the reliable fallback.
+    console.log(
+      chalk.dim(
+        '  Tip: mDNS often does not cross subnets. If the device is reachable by IP, ' +
+          'add it directly: ff-cli device add --host http://<device-ip>:1111 --name <name>'
+      )
+    );
   }
 
   // Manual entry fallback

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -4,19 +4,58 @@ import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import { findExistingDeviceEntry } from '../utilities/device-lookup';
 import { upsertDevice } from '../utilities/device-upsert';
+import { normalizeDeviceHost } from '../utilities/device-normalize';
 import { ensureConfigFile, isMissingConfigValue, readConfigFile } from './helpers/config-files';
 import { discoverAndSelectDevice } from './helpers/device-discovery';
 import { createPrompt, promptYesNo } from './helpers/prompt';
 import { configuredFF1Devices } from '../utilities/config-placeholders';
+import { parsePlaylistPrivateKeyToKeyObject } from '../utilities/ed25519-key-derive';
 import {
   DP1_PLAYLIST_SIGNING_ROLES,
   resolveDp1PlaylistSigningRole,
 } from '../utilities/playlist-signing-role';
 
+interface SetupOptions {
+  nonInteractive?: boolean;
+  key?: string;
+  generateKey?: boolean;
+  role?: string;
+  deviceHost?: string;
+  deviceName?: string;
+}
+
+/** Generate a fresh Ed25519 signing key as base64 PKCS#8 DER (the recommended form). */
+function generateSigningKeyBase64(): string {
+  const keyPair = crypto.generateKeyPairSync('ed25519');
+  return keyPair.privateKey.export({ format: 'der', type: 'pkcs8' }).toString('base64');
+}
+
 export const setupCommand = new Command('setup')
   .description('Guided setup for config, signing key, and device')
-  .action(async () => {
+  .option(
+    '-y, --non-interactive',
+    'Run without prompts (for agents/CI); uses flags and safe defaults. Auto-enabled when stdin is not a TTY.'
+  )
+  .option(
+    '--key <privateKey>',
+    'Signing key material (base64 PKCS#8 DER, 32-byte seed as hex/base64, or PEM)'
+  )
+  .option('--generate-key', 'Generate a new Ed25519 signing key')
+  .option('--role <role>', `Signing role (${DP1_PLAYLIST_SIGNING_ROLES.join(', ')})`)
+  .option(
+    '--device-host <host>',
+    'FF1 device host, e.g. http://192.168.1.50:1111 (skips mDNS discovery)'
+  )
+  .option('--device-name <name>', 'Friendly name for the device')
+  .action(async (options: SetupOptions) => {
+    // Treat a non-TTY stdin as non-interactive: agents driving the CLI cannot
+    // answer prompts, and the report shows feeding stdin to the prompts does not
+    // work. The explicit flag forces it even on a TTY.
+    const nonInteractive = Boolean(options.nonInteractive) || !process.stdin.isTTY;
+
     let prompt: ReturnType<typeof createPrompt> | null = null;
+    // Lazily open the prompt so non-interactive runs never touch stdin.
+    const getAsk = () => (prompt ??= createPrompt()).ask;
     try {
       const { path: configPath, created } = await ensureConfigFile();
       if (created) {
@@ -25,49 +64,75 @@ export const setupCommand = new Command('setup')
 
       const config = await readConfigFile(configPath);
 
-      console.log(chalk.blue('\nff-cli setup\n'));
-
-      prompt = createPrompt();
-      const ask = prompt.ask;
+      console.log(chalk.blue(`\nff-cli setup${nonInteractive ? ' (non-interactive)' : ''}\n`));
 
       const currentKey = config.playlist?.privateKey || '';
       const currentRole = config.playlist?.role || '';
       let signingKey = currentKey;
       let signingRole = currentRole;
 
-      if (isMissingConfigValue(currentKey)) {
-        const keyPair = crypto.generateKeyPairSync('ed25519');
-        signingKey = keyPair.privateKey.export({ format: 'der', type: 'pkcs8' }).toString('base64');
+      if (nonInteractive) {
+        // Key precedence: explicit --key, then --generate-key, then keep an
+        // existing usable key, otherwise generate one so signing works.
+        if (options.key) {
+          // Validate eagerly so a bad key fails here with a clear message rather
+          // than later inside dp1-js during signing.
+          try {
+            parsePlaylistPrivateKeyToKeyObject(options.key);
+          } catch (error) {
+            throw new Error(
+              `Invalid --key: ${(error as Error).message}. ` +
+                'Expected base64 PKCS#8 DER, a 32-byte raw seed as hex/base64, or PEM.'
+            );
+          }
+          signingKey = options.key;
+        } else if (options.generateKey || isMissingConfigValue(currentKey)) {
+          signingKey = generateSigningKeyBase64();
+          console.log(chalk.dim('Generated a new Ed25519 signing key.'));
+        }
       } else {
-        const keepKey = await promptYesNo(ask, 'Keep existing signing key?', true);
-        if (!keepKey) {
-          const keyAnswer = await ask(
-            'Paste signing key (base64 or hex), or leave blank to regenerate: '
-          );
-          if (keyAnswer) {
-            signingKey = keyAnswer;
-          } else {
-            const keyPair = crypto.generateKeyPairSync('ed25519');
-            signingKey = keyPair.privateKey
-              .export({ format: 'der', type: 'pkcs8' })
-              .toString('base64');
+        if (isMissingConfigValue(currentKey)) {
+          signingKey = generateSigningKeyBase64();
+        } else {
+          const ask = getAsk();
+          const keepKey = await promptYesNo(ask, 'Keep existing signing key?', true);
+          if (!keepKey) {
+            const keyAnswer = await ask(
+              'Paste signing key (base64 or hex), or leave blank to regenerate: '
+            );
+            signingKey = keyAnswer || generateSigningKeyBase64();
           }
         }
       }
 
       if (signingKey) {
-        const roleHint = DP1_PLAYLIST_SIGNING_ROLES.join(', ');
-        while (true) {
-          const roleAnswer = await ask(`Signing role (${roleHint}) [${currentRole || 'agent'}]: `);
+        if (nonInteractive) {
+          // Role precedence: --role, then existing role, then 'agent'.
           try {
-            signingRole = resolveDp1PlaylistSigningRole(roleAnswer, signingRole || 'agent');
-            break;
+            signingRole = resolveDp1PlaylistSigningRole(options.role, signingRole || 'agent');
           } catch (error) {
-            console.log(chalk.red((error as Error).message));
-            if (!roleAnswer.trim()) {
-              console.log(
-                chalk.dim('Enter one of the supported roles above, or fix the stored value.')
-              );
+            throw new Error(
+              `Invalid --role: ${(error as Error).message} ` +
+                `Supported roles: ${DP1_PLAYLIST_SIGNING_ROLES.join(', ')}.`
+            );
+          }
+        } else {
+          const ask = getAsk();
+          const roleHint = DP1_PLAYLIST_SIGNING_ROLES.join(', ');
+          while (true) {
+            const roleAnswer = await ask(
+              `Signing role (${roleHint}) [${currentRole || 'agent'}]: `
+            );
+            try {
+              signingRole = resolveDp1PlaylistSigningRole(roleAnswer, signingRole || 'agent');
+              break;
+            } catch (error) {
+              console.log(chalk.red((error as Error).message));
+              if (!roleAnswer.trim()) {
+                console.log(
+                  chalk.dim('Enter one of the supported roles above, or fix the stored value.')
+                );
+              }
             }
           }
         }
@@ -94,77 +159,116 @@ export const setupCommand = new Command('setup')
         );
       }
 
-      const selection = await discoverAndSelectDevice(ask, existingDevices, { allowSkip: true });
-
-      if (selection.hostValue) {
-        // Prefer the already-stored label so re-running setup (or re-adding a device
-        // that returned on a new IP) doesn't clobber the friendly name.
-        const existingEntry = findExistingDeviceEntry(
-          existingDevices,
-          selection.hostValue,
-          selection.discoveredName,
-          selection.discoveredId,
-          selection.discoveredAddresses
-        );
-        const existingIndex = existingEntry
-          ? existingDevices.findIndex((d) => d === existingEntry)
-          : -1;
-        const existingName = existingEntry?.name || '';
-        const defaultName = existingName || selection.discoveredName || 'art-computer';
-        const namePrompt =
-          defaultName !== 'art-computer'
-            ? `Device name (kitchen, office, etc.) [${defaultName}]: `
-            : 'Device name (kitchen, office, etc.): ';
-        const nameAnswer = await ask(namePrompt);
-        let deviceName = nameAnswer || defaultName || 'art-computer';
-
-        // Same name-collision guard as `device add`: reject names that would
-        // clobber a different device entry. Only fires when existingIndex !== -1
-        // (we know the row); when existingIndex === -1, a same-name entry is the
-        // case-3 migration path.
-        const setupNameConflict =
-          existingIndex !== -1
-            ? existingDevices.find((d, i) => d.name === deviceName && i !== existingIndex)
-            : undefined;
-        if (setupNameConflict) {
-          console.log(
-            chalk.yellow(
-              `"${deviceName}" is already used by another device. Please choose a different name.`
-            )
+      if (nonInteractive) {
+        // Non-interactive device step: only act when a host is supplied. mDNS
+        // discovery is interactive and unreliable across subnets, so we never
+        // run it here — agents should pass --device-host.
+        if (options.deviceHost) {
+          const hostValue = normalizeDeviceHost(options.deviceHost);
+          const existingEntry = findExistingDeviceEntry(
+            existingDevices,
+            hostValue,
+            '',
+            undefined,
+            undefined
           );
-          const retryAnswer = await ask('Device name: ');
-          deviceName = retryAnswer || 'art-computer';
-          const retryConflict =
+          const existingIndex = existingEntry
+            ? existingDevices.findIndex((d) => d === existingEntry)
+            : -1;
+          const deviceName = options.deviceName || existingEntry?.name || 'art-computer';
+          const result = upsertDevice(
+            existingDevices,
+            { name: deviceName, host: hostValue },
+            existingIndex !== -1 ? existingIndex : undefined
+          );
+          console.log(chalk.dim(`${result.updated ? 'Updated' : 'Added'} device: ${deviceName}`));
+          config.ff1Devices = { devices: result.devices };
+        } else {
+          config.ff1Devices = { devices: existingDevices };
+          if (existingDevices.length === 0) {
+            console.log(
+              chalk.dim(
+                'No device configured. Add one with: ff-cli device add --host http://<device-ip>:1111 --name <name>'
+              )
+            );
+          }
+        }
+      } else {
+        const ask = getAsk();
+        const selection = await discoverAndSelectDevice(ask, existingDevices, { allowSkip: true });
+
+        if (selection.hostValue) {
+          // Prefer the already-stored label so re-running setup (or re-adding a device
+          // that returned on a new IP) doesn't clobber the friendly name.
+          const existingEntry = findExistingDeviceEntry(
+            existingDevices,
+            selection.hostValue,
+            selection.discoveredName,
+            selection.discoveredId,
+            selection.discoveredAddresses
+          );
+          const existingIndex = existingEntry
+            ? existingDevices.findIndex((d) => d === existingEntry)
+            : -1;
+          const existingName = existingEntry?.name || '';
+          const defaultName = existingName || selection.discoveredName || 'art-computer';
+          const namePrompt =
+            defaultName !== 'art-computer'
+              ? `Device name (kitchen, office, etc.) [${defaultName}]: `
+              : 'Device name (kitchen, office, etc.): ';
+          const nameAnswer = await ask(namePrompt);
+          let deviceName = nameAnswer || defaultName || 'art-computer';
+
+          // Same name-collision guard as `device add`: reject names that would
+          // clobber a different device entry. Only fires when existingIndex !== -1
+          // (we know the row); when existingIndex === -1, a same-name entry is the
+          // case-3 migration path.
+          const setupNameConflict =
             existingIndex !== -1
               ? existingDevices.find((d, i) => d.name === deviceName && i !== existingIndex)
               : undefined;
-          if (retryConflict) {
-            console.log(chalk.yellow(`"${deviceName}" is also taken. Skipping device.`));
-            config.ff1Devices = { devices: existingDevices };
-            await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
-            return;
+          if (setupNameConflict) {
+            console.log(
+              chalk.yellow(
+                `"${deviceName}" is already used by another device. Please choose a different name.`
+              )
+            );
+            const retryAnswer = await ask('Device name: ');
+            deviceName = retryAnswer || 'art-computer';
+            const retryConflict =
+              existingIndex !== -1
+                ? existingDevices.find((d, i) => d.name === deviceName && i !== existingIndex)
+                : undefined;
+            if (retryConflict) {
+              console.log(chalk.yellow(`"${deviceName}" is also taken. Skipping device.`));
+              config.ff1Devices = { devices: existingDevices };
+              await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+              return;
+            }
           }
-        }
 
-        const result = upsertDevice(
-          existingDevices,
-          {
-            name: deviceName,
-            host: selection.hostValue,
-            id: selection.discoveredId,
-            addresses: selection.discoveredAddresses,
-          },
-          existingIndex !== -1 ? existingIndex : undefined
-        );
-        console.log(chalk.dim(`${result.updated ? 'Updated' : 'Added'} device: ${deviceName}`));
-        config.ff1Devices = { devices: result.devices };
-      } else if (existingDevices.length > 0) {
-        config.ff1Devices = { devices: existingDevices };
+          const result = upsertDevice(
+            existingDevices,
+            {
+              name: deviceName,
+              host: selection.hostValue,
+              id: selection.discoveredId,
+              addresses: selection.discoveredAddresses,
+            },
+            existingIndex !== -1 ? existingIndex : undefined
+          );
+          console.log(chalk.dim(`${result.updated ? 'Updated' : 'Added'} device: ${deviceName}`));
+          config.ff1Devices = { devices: result.devices };
+        } else if (existingDevices.length > 0) {
+          config.ff1Devices = { devices: existingDevices };
+        }
       }
 
       await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
-      prompt.close();
-      prompt = null;
+      if (prompt) {
+        prompt.close();
+        prompt = null;
+      }
 
       console.log(chalk.green('\nSetup complete'));
       console.log(chalk.dim(`   Config: ${configPath}`));

--- a/src/config.ts
+++ b/src/config.ts
@@ -309,17 +309,24 @@ export async function createSampleConfig(targetPath?: string): Promise<string> {
     throw new Error('config.json already exists');
   }
 
-  // Look for config.json.example in the package directory
-  // When compiled, this file is in dist/src/config.js
-  // The template is at the package root: ../../config.json.example
+  // Look for config.json.example across the layouts we ship in:
+  //  - cwd: running from a source checkout
+  //  - __dirname/../..: npm install (this file is dist/src/config.js, template
+  //    sits at the package root)
+  //  - __dirname/..: single-file release bundle (this file is bundled into
+  //    lib/ff-cli.js, template sits one level up at the package root)
   const exampleCandidates = [
     path.join(process.cwd(), 'config.json.example'),
     path.join(__dirname, '../..', 'config.json.example'),
+    path.join(__dirname, '..', 'config.json.example'),
   ];
   const examplePath = exampleCandidates.find((candidate) => fs.existsSync(candidate));
 
   if (!examplePath) {
-    throw new Error('config.json.example not found. This is likely a package installation issue.');
+    throw new Error(
+      'config.json.example not found (likely an incomplete install). ' +
+        'Reinstall with: npm i -g @feralfile/cli'
+    );
   }
 
   const exampleConfig = fs.readFileSync(examplePath, 'utf-8');

--- a/src/utilities/ed25519-key-derive.ts
+++ b/src/utilities/ed25519-key-derive.ts
@@ -113,6 +113,19 @@ export function parsePlaylistPrivateKeyToKeyObject(material: string): KeyObject 
     } catch {
       // Continue to other strategies (e.g. hex path may apply for unusual configs)
     }
+    // A 32-byte base64 value is a raw Ed25519 seed (not PKCS#8). The example
+    // config's `_BASE64_OR_HEX` placeholder invites this, so accept it by
+    // wrapping the seed in a PKCS#8 envelope, mirroring the hex-seed path.
+    if (buf.length === 32) {
+      try {
+        const der = ed25519SeedBytesToPkcs8(buf);
+        const key = createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+        assertEd25519(key);
+        return key;
+      } catch {
+        // fall through to remaining strategies
+      }
+    }
   }
 
   if (hexRegex.test(trimmed)) {

--- a/src/utilities/ff1-device.ts
+++ b/src/utilities/ff1-device.ts
@@ -216,8 +216,14 @@ export async function sendPlaylistToDevice({
       headers['API-KEY'] = device.apiKey;
     }
 
-    // Make the API request with bounded retries for transient local network errors.
+    // Make the API request with bounded retries for transient local network
+    // errors, device rate-limiting, and empty/non-JSON bodies (the device can
+    // return an empty response on the first cast after boot).
     let response: Response | null = null;
+    let responseData: Record<string, unknown> = {};
+    // Describes a 2xx response whose body could not be parsed, so the post-loop
+    // handler can report it clearly if every attempt is exhausted.
+    let lastBodyIssue: string | null = null;
     for (let attempt = 1; attempt <= SEND_RETRY_ATTEMPTS; attempt += 1) {
       try {
         response = await fetch(apiUrl, {
@@ -242,6 +248,39 @@ export async function sendPlaylistToDevice({
           await waitForRetry(retryDelay);
           continue;
         }
+
+        // Non-2xx (other than 429 handled above): surface via the post-loop
+        // handler, which re-reads the body as error text.
+        if (!response.ok) {
+          break;
+        }
+
+        // 2xx: read the body defensively. An empty or non-JSON body is a known
+        // transient hiccup (commonly the first cast after boot), so retry within
+        // the attempt budget instead of throwing "Unexpected end of JSON input".
+        const bodyText = (await response.text()).trim();
+        if (bodyText === '') {
+          lastBodyIssue = 'device returned an empty response body';
+        } else {
+          try {
+            responseData = JSON.parse(bodyText) as Record<string, unknown>;
+            lastBodyIssue = null;
+            break;
+          } catch {
+            lastBodyIssue = `device returned a non-JSON response body: ${bodyText.slice(0, 200)}`;
+          }
+        }
+
+        if (attempt < SEND_RETRY_ATTEMPTS) {
+          const retryDelay = SEND_RETRY_BASE_DELAY_MS * attempt;
+          logger.warn(
+            `${lastBodyIssue} (attempt ${attempt}/${SEND_RETRY_ATTEMPTS}); retrying in ${retryDelay}ms`
+          );
+          response = null;
+          await waitForRetry(retryDelay);
+          continue;
+        }
+        // Out of attempts; let the post-loop handler report the body issue.
         break;
       } catch (error) {
         const shouldRetry = attempt < SEND_RETRY_ATTEMPTS && isTransientDeviceNetworkError(error);
@@ -293,8 +332,22 @@ export async function sendPlaylistToDevice({
       };
     }
 
-    // Parse response
-    const responseData = (await response.json()) as Record<string, unknown>;
+    // 2xx but the body never parsed within the retry budget: report the HTTP
+    // status and what was wrong rather than crashing on a JSON parse error.
+    if (lastBodyIssue) {
+      const deviceLabel = device.name || device.host;
+      logger.error(
+        `Cast to "${deviceLabel}" returned HTTP ${response.status} but ${lastBodyIssue}`
+      );
+      return {
+        success: false,
+        error: `Device "${deviceLabel}" accepted the request (HTTP ${response.status}) but returned no usable response`,
+        details:
+          `${lastBodyIssue}. This is often transient on the first cast after boot — ` +
+          'wait a few seconds and try again.',
+      };
+    }
+
     logger.info('Successfully sent playlist to FF1 device');
     logger.debug(`Device response: ${JSON.stringify(responseData)}`);
 

--- a/src/utilities/playlist-signer.js
+++ b/src/utilities/playlist-signer.js
@@ -5,6 +5,30 @@
 
 const { getPlaylistConfig } = require('../config');
 const { isDp1PlaylistSigningRole } = require('./playlist-signing-role');
+const { parsePlaylistPrivateKeyToKeyObject } = require('./ed25519-key-derive');
+
+/**
+ * Normalize any supported signing-key encoding to base64 PKCS#8 DER, the form
+ * dp1-js's signer expects. This makes hex seeds, base64 seeds, and PEM work for
+ * signing (not just base64 PKCS#8), and replaces dp1-js's cryptic OpenSSL error
+ * (e.g. "header too long") with actionable guidance when the key is malformed.
+ *
+ * @param {string} material - Raw key string from config or --key
+ * @returns {string} base64-encoded PKCS#8 DER Ed25519 private key
+ */
+function normalizeSigningKeyToBase64Pkcs8(material) {
+  let keyObject;
+  try {
+    keyObject = parsePlaylistPrivateKeyToKeyObject(material);
+  } catch (error) {
+    throw new Error(
+      `Invalid Ed25519 signing key: ${error.message}. Provide a base64 PKCS#8 DER key ` +
+        '(recommended), a 32-byte raw seed as hex or base64, or a PEM key. ' +
+        'Run `ff-cli setup` to generate one.'
+    );
+  }
+  return keyObject.export({ format: 'der', type: 'pkcs8' }).toString('base64');
+}
 
 /**
  * Sign a playlist using the DP-1 signing API.
@@ -38,9 +62,10 @@ async function signPlaylist(playlist, privateKeyBase64, roleOverride) {
     const raw = Buffer.from(JSON.stringify(playlistToSign));
     const config = getPlaylistConfig();
     const role = resolvePlaylistSigningRole(roleOverride || config.role);
+    const normalizedKey = normalizeSigningKeyToBase64Pkcs8(privateKey);
 
     if (typeof dp1.SignMultiEd25519 === 'function') {
-      return dp1.SignMultiEd25519(raw, privateKey, role, currentTimestamp());
+      return dp1.SignMultiEd25519(raw, normalizedKey, role, currentTimestamp());
     }
 
     throw new Error('dp1-js does not expose SignMultiEd25519');
@@ -190,6 +215,11 @@ async function buildSignedPlaylistEnvelope(playlist, privateKey, dp1, role) {
   delete playlistToSign.signature;
   delete playlistToSign.signatures;
 
+  // Normalize to base64 PKCS#8 DER so any supported key encoding (hex/base64
+  // seed, PEM) works and a malformed key surfaces a clear error instead of
+  // dp1-js's cryptic OpenSSL ASN.1 failure ("header too long" / "wrong tag").
+  const normalizedKey = normalizeSigningKeyToBase64Pkcs8(privateKey);
+
   const existingSignatures = Array.isArray(playlist.signatures)
     ? playlist.signatures.filter((entry) => Boolean(entry))
     : [];
@@ -197,7 +227,7 @@ async function buildSignedPlaylistEnvelope(playlist, privateKey, dp1, role) {
   if (typeof dp1.SignMultiEd25519 === 'function') {
     const signature = await dp1.SignMultiEd25519(
       Buffer.from(JSON.stringify(playlistToSign)),
-      privateKey,
+      normalizedKey,
       role,
       currentTimestamp()
     );
@@ -236,9 +266,13 @@ async function verifySignedPlaylistEnvelope(signedPlaylist, dp1) {
   return { valid: true };
 }
 
-/** Loads `dp1-js`; env overrides are not supported (see playlist-verifier). */
+/**
+ * Loads `dp1-js`; env overrides are not supported (see playlist-verifier).
+ * Uses dynamic `import()` so the single-file release bundle inlines dp1-js
+ * instead of leaving a runtime require that can't resolve.
+ */
 async function loadDp1() {
-  return require('dp1-js');
+  return import('dp1-js');
 }
 
 function currentTimestamp() {

--- a/src/utilities/playlist-verifier.ts
+++ b/src/utilities/playlist-verifier.ts
@@ -7,7 +7,6 @@
 import type { Playlist } from '../types';
 import chalk from 'chalk';
 import { promises as fs } from 'fs';
-import { createRequire } from 'module';
 
 /**
  * Cryptographically verify a playlist via dp1-js (after parsing succeeds).
@@ -155,10 +154,15 @@ async function parseDp1Playlist(playlist: unknown): Promise<{
  * Loads the published DP-1 implementation bundled with the CLI (`dp1-js`).
  * Local checkout overrides via environment are intentionally unsupported so
  * resolution stays deterministic across machines and CI.
+ *
+ * Uses a dynamic `import()` (not `createRequire`) so the single-file release
+ * bundle inlines dp1-js: esbuild can follow `import('dp1-js')` and pull the
+ * module into the bundle, whereas a `createRequire(__filename)` require escapes
+ * bundling and fails at runtime with "Cannot find module 'dp1-js'". The import
+ * stays lazy, so dp1-js's transitive deps don't load on unrelated commands.
  */
 async function loadDp1(): Promise<Record<string, unknown>> {
-  const require = createRequire(__filename);
-  return require('dp1-js');
+  return (await import('dp1-js')) as unknown as Record<string, unknown>;
 }
 
 /**

--- a/tests/ed25519-key-derive.test.ts
+++ b/tests/ed25519-key-derive.test.ts
@@ -61,4 +61,37 @@ describe('ed25519-key-derive', () => {
     const roundTripPub = createPublicKey(ko).export({ format: 'pem', type: 'spki' }).toString();
     assert.equal(roundTripPub, deriveEd25519PublicKeyForVerify(pkcs8B64));
   });
+
+  test('parsePlaylistPrivateKeyToKeyObject accepts a 32-byte raw seed as base64', () => {
+    // The example config invites a base64 "raw seed"; both seed encodings must
+    // resolve to the same key as the PKCS#8 form of that seed.
+    const seed = randomBytes(32);
+    const pkcs8 = Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), seed]);
+    const expectedPub = createPublicKey(
+      createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' })
+    )
+      .export({ format: 'pem', type: 'spki' })
+      .toString();
+
+    const ko = parsePlaylistPrivateKeyToKeyObject(seed.toString('base64'));
+    assert.equal(ko.asymmetricKeyType, 'ed25519');
+    assert.equal(
+      createPublicKey(ko).export({ format: 'pem', type: 'spki' }).toString(),
+      expectedPub
+    );
+    // The base64 seed and hex seed must yield the same key.
+    assert.equal(
+      createPublicKey(parsePlaylistPrivateKeyToKeyObject(seed.toString('hex')))
+        .export({ format: 'pem', type: 'spki' })
+        .toString(),
+      expectedPub
+    );
+  });
+
+  test('parsePlaylistPrivateKeyToKeyObject rejects garbage with an actionable message', () => {
+    assert.throws(
+      () => parsePlaylistPrivateKeyToKeyObject('not-a-real-key-zzz'),
+      /Unrecognized Ed25519 private key format/
+    );
+  });
 });

--- a/tests/ff1-device-cast-body.test.ts
+++ b/tests/ff1-device-cast-body.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { sendPlaylistToDevice } from '../src/utilities/ff1-device';
+
+// Exercises the cast response handling: an empty or non-JSON body from the
+// device must not crash with "Unexpected end of JSON input". A transient empty
+// body should be retried (the device commonly returns one on the first cast
+// after boot), and a persistently empty body should yield a clear error.
+
+interface MockResponse {
+  status: number;
+  ok: boolean;
+  statusText: string;
+  headers: { get: () => string | null };
+  text: () => Promise<string>;
+  json: () => Promise<unknown>;
+}
+
+const originalCwd = process.cwd();
+const originalFetch = global.fetch;
+let fixtureDir: string;
+
+const makeResponse = (body: string, init?: Partial<MockResponse>): MockResponse => ({
+  status: init?.status ?? 200,
+  ok: init?.ok ?? true,
+  statusText: init?.statusText ?? 'OK',
+  headers: { get: () => null },
+  text: async () => body,
+  json: async () => JSON.parse(body),
+});
+
+// The compatibility probe (command: getDeviceStatus) runs before the cast.
+// Returning a 500 makes assertFF1CommandCompatibility treat the device as
+// compatible without needing a version, isolating the cast-body behavior.
+const compatibilityProbeResponse = (): MockResponse =>
+  makeResponse('{}', { status: 500, ok: false, statusText: 'Internal Server Error' });
+
+const installFetchMock = (castHandler: () => MockResponse): void => {
+  global.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
+    const body = options?.body ? JSON.parse(options.body as string) : undefined;
+    if (body?.command === 'getDeviceStatus') {
+      return compatibilityProbeResponse() as unknown as Response;
+    }
+    return castHandler() as unknown as Response;
+  }) as unknown as typeof global.fetch;
+};
+
+const writeDeviceConfig = (): void => {
+  writeFileSync(
+    path.join(process.cwd(), 'config.json'),
+    JSON.stringify({ ff1Devices: { devices: [{ name: 'Frame', host: 'http://ff1.local' }] } }),
+    'utf8'
+  );
+};
+
+const samplePlaylist = {
+  dpVersion: '1.1.0',
+  id: 'test',
+  items: [],
+} as unknown as Parameters<typeof sendPlaylistToDevice>[0]['playlist'];
+
+describe('sendPlaylistToDevice cast-body handling', () => {
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(path.join(os.tmpdir(), 'ff1-cast-body-test-'));
+    process.chdir(fixtureDir);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.chdir(originalCwd);
+    if (fixtureDir && existsSync(fixtureDir)) {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  test('retries an empty body and succeeds when a later attempt returns JSON', async () => {
+    writeDeviceConfig();
+    let castAttempt = 0;
+    installFetchMock(() => {
+      castAttempt += 1;
+      return castAttempt === 1 ? makeResponse('') : makeResponse('{"ok":true}');
+    });
+
+    const result = await sendPlaylistToDevice({ playlist: samplePlaylist });
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.response, { ok: true });
+    assert.equal(castAttempt, 2, 'should have retried after the empty body');
+  });
+
+  test('reports a clear error (not a JSON parse crash) when the body stays empty', async () => {
+    writeDeviceConfig();
+    installFetchMock(() => makeResponse(''));
+
+    const result = await sendPlaylistToDevice({ playlist: samplePlaylist });
+
+    assert.equal(result.success, false);
+    assert.match(result.error || '', /returned no usable response/);
+    assert.match(result.details || '', /empty response body/);
+    // Crucially, the failure is not the raw JSON parse error.
+    assert.doesNotMatch(result.error || '', /Unexpected end of JSON input/);
+  });
+});


### PR DESCRIPTION
Addresses a detailed customer report (Bre Pettis) on the agent-driven FF1 workflow: the prebuilt installer was unusable and several flows fought the agent-first design. This fixes all reported issues plus related improvements.

## Issues fixed

**1. The curl/tarball install was unusable (3 bugs)** — npm install was unaffected.
- **Symlink launcher**: generated `bin/ff-cli` computed its base dir from `$0` without resolving symlinks, so invoked via `~/.local/bin/ff-cli` it looked for `~/.local/lib/ff-cli.js` instead of the real `lib/`. Now resolves the symlink chain.
- **Missing `config.json.example`**: never copied into the tarball, and the lookup didn't account for the bundle's `lib/` layout. Now shipped + a `<bundle>/lib/../config.json.example` lookup candidate; missing-file error points at `npm i -g @feralfile/cli`.
- **`dp1-js` not bundled**: `playlist-verifier` loaded it via `createRequire(__filename)`, which esbuild can't follow, so `verify`/`sign` crashed with `Cannot find module 'dp1-js'`. Now loaded via a lazy `import()` that esbuild inlines.

**2. Signing key format** — signing handed the raw key to dp1-js, so a 32-byte raw seed failed with OpenSSL's cryptic `header too long` / `wrong tag`, and only base64 PKCS#8 DER worked. Now any documented encoding (base64 PKCS#8 DER, 32-byte seed as hex/base64, PKCS#8 hex, PEM) is normalized to base64 PKCS#8 DER before dp1-js, with an actionable error for malformed keys. Fixed the misleading config placeholder.

**4. mDNS discovery** — interactive "no devices found" messages now point at the reliable `device add --host` fallback and note cross-subnet limits.

**5. Interactive prompts blocked agents** — `ff-cli setup` gained `-y/--non-interactive`, `--generate-key`, `--key`, `--role`, `--device-host`, `--device-name`, and auto-enables non-interactive mode when stdin is not a TTY.

**6. Opaque first-cast error** — empty/non-JSON device responses threw `Unexpected end of JSON input`. Now an empty 2xx body is retried within the existing budget, and persistent failures report the HTTP status with an actionable message.

**7. Docs gaps** — documented static signed-URL playback (no feed server needed), the device cast contract incl. the required `intent` field, key encodings, npm-first install, and added a non-interactive bootstrap to the `ff-control` agent skill.

## Verification
- `npm run verify` green; test suite 370 → **374** (added coverage for base64-seed parsing, the garbage-key error, and the empty-body cast recovery/exhaustion paths).
- End-to-end smoke through a **simulated curl-install layout** (symlinked launcher → `--version`, `verify`, `config init`, `setup --non-interactive`, `sign`+`verify` with the generated key) — all pass.

## Note
The installer fixes live in the release bundle/script, so they only reach users once a **new release is cut** — the published `2.0.1` tarball stays broken until then. npm install was never affected.
