### PR TITLE
fix(timing): stamp a duration on generative works so playlists rotate

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,6 @@
 {
   "defaultDuration": 10,
+  "generativeDuration": 60,
   "browser": {
     "timeout": 90000,
     "sanitizationLevel": "medium"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,8 +22,11 @@ npm run dev -- config show
 ## Top‑level fields
 
 - **defaultDuration** (number, seconds)
-  - Default per‑item display duration for media without an intrinsic runtime (images, code-based works). Falls back to 10s when unset.
+  - Default per‑item display duration for static media without an intrinsic runtime (images). Falls back to 10s when unset.
   - Does NOT apply to video/audio items: with no explicit duration those are emitted without `duration` and with `display.loop: false`, so a DP-1 player advances at end-of-stream (§4.1) — the media plays its natural length.
+- **generativeDuration** (number, seconds)
+  - Display duration stamped on generative/interactive (HTML) works, which have no intrinsic runtime and no end-of-stream event. Defaults to **60s** (override via `DEFAULT_GENERATIVE_DURATION`).
+  - Set to **0** to omit the duration entirely, so a conformant player parks on the work open-ended instead of rotating. Note: some players (including FF1) require every item to carry a `duration` and will reject a playlist whose items omit it — keep this non-zero unless you know your player tolerates an absent duration.
 
 ## browser
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ function loadConfig(): Config {
 
   const defaultConfig: Config = {
     defaultDuration: parseInt(process.env.DEFAULT_DURATION || '10', 10),
+    generativeDuration: parseInt(process.env.DEFAULT_GENERATIVE_DURATION || '60', 10),
     browser: {
       timeout: parseInt(process.env.BROWSER_TIMEOUT || '90000', 10),
       sanitizationLevel: process.env.SANITIZATION_LEVEL || 'medium',

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,12 @@ export interface IndexerConfig {
 
 export interface Config {
   defaultDuration: number;
+  /**
+   * Display seconds stamped on generative/interactive (HTML) works, which have
+   * no intrinsic runtime. Defaults to 60. Set to 0 to omit the duration so a
+   * conformant player parks on the work open-ended instead of rotating.
+   */
+  generativeDuration: number;
   browser: BrowserConfig;
   feed?: FeedConfig; // Legacy
   feedServers?: FeedServer[]; // New: array of feed servers with individual API keys

--- a/src/utilities/playlist-builder.js
+++ b/src/utilities/playlist-builder.js
@@ -52,16 +52,18 @@ function isInteractiveWeb(mimeType, sourceUrl) {
  *   - a time-based source (video/audio) gets NO duration and
  *     `display.loop: false`, so a conformant player MUST advance at
  *     end-of-stream — the media plays its natural length;
- *   - an interactive web page (HTML) gets NO duration either, but for the
- *     opposite reason: it has no end-of-stream event, so a conformant player
- *     parks on it indefinitely (the generative/interactive art keeps running);
+ *   - an interactive web page (HTML) — generative art with no intrinsic
+ *     runtime and no end-of-stream event — gets the configured
+ *     `generativeDuration` (default 60s) so the playlist rotates. Set
+ *     `generativeDuration` to 0 to omit it and have a conformant player park
+ *     on the work open-ended instead;
  *   - static and code-based sources fall back to the configured
  *     `defaultDuration` because they have no intrinsic runtime to play out.
  *
- * Do not re-introduce an unconditional duration here: stamping a default on
- * video items silently truncates or pads them, and stamping one on an HTML
- * page cuts the artwork off and restarts it every `defaultDuration` seconds
- * (the bugs this guards against).
+ * Do not stamp a duration on video/audio: it silently truncates or pads them.
+ * (Earlier this also omitted duration for HTML works, which left them with no
+ * duration field. Players that require the field — notably FF1 — then rejected
+ * the entire playlist, so generative works now carry an explicit duration.)
  *
  * @param {Object} item - DP1 playlist item (mutated in place)
  * @param {Object} mediaHints - Media signals for the time-based check
@@ -82,8 +84,13 @@ function applyItemTiming(item, mediaHints = {}, duration) {
   }
 
   if (isInteractiveWeb(mediaHints.mimeType, mediaHints.sourceUrl)) {
-    // No duration: an open-ended interactive page should play until the
-    // playlist advances for another reason, not on a fixed timer.
+    // Generative/interactive works have no intrinsic runtime, so stamp the
+    // configured generative duration to drive playlist rotation. A configured
+    // value of 0 means "omit" — a conformant player then parks open-ended.
+    const generativeDuration = getGenerativeDuration();
+    if (generativeDuration > 0) {
+      item.duration = generativeDuration;
+    }
     return item;
   }
 
@@ -103,6 +110,23 @@ function getDefaultStaticDuration() {
     return getConfig().defaultDuration || 10;
   } catch (_error) {
     return 10;
+  }
+}
+
+/**
+ * getGenerativeDuration returns the configured display seconds for
+ * generative/interactive (HTML) works, which have no intrinsic runtime.
+ * Defaults to 60 when config is unavailable. A configured 0 is honored (the
+ * caller omits the duration so the work plays open-ended).
+ *
+ * @returns {number} Display duration in seconds (0 means "omit / open-ended")
+ */
+function getGenerativeDuration() {
+  try {
+    const configured = getConfig().generativeDuration;
+    return typeof configured === 'number' ? configured : 60;
+  } catch (_error) {
+    return 60;
   }
 }
 

--- a/tests/playlist-item-timing.test.ts
+++ b/tests/playlist-item-timing.test.ts
@@ -6,8 +6,10 @@
  * `display.loop: false` and no duration MUST advance at end-of-stream — the
  * media plays its natural length. These tests pin the auto-timing contract:
  * omitted duration → video/audio items carry no duration and loop=false,
- * static items fall back to the configured default, and an explicit duration
- * always wins regardless of media type.
+ * static items fall back to the configured default, generative/interactive
+ * (HTML) works carry the configured `generativeDuration` (default 60, or
+ * omitted when set to 0), and an explicit duration always wins regardless of
+ * media type.
  */
 
 import assert from 'node:assert/strict';
@@ -84,18 +86,53 @@ describe('applyItemTiming', () => {
     assert.ok((item.duration as number) >= 1);
   });
 
-  test('auto + interactive HTML: no duration (player parks indefinitely)', () => {
+  test('auto + interactive HTML: carries the generative duration (drives rotation)', () => {
     const item: Record<string, unknown> = { display: { scaling: 'fit' } };
     applyItemTiming(item, { mimeType: 'text/html', sourceUrl: 'https://e.com/art' });
-    assert.equal('duration' in item, false);
+    assert.equal(typeof item.duration, 'number');
+    assert.ok((item.duration as number) >= 1);
     // Unlike video, no loop:false — an HTML page has no end-of-stream event.
     assert.deepEqual(item.display, { scaling: 'fit' });
   });
 
-  test('auto + interactive HTML by .html extension: no duration', () => {
+  test('auto + interactive HTML by .html extension: carries the generative duration', () => {
     const item: Record<string, unknown> = {};
     applyItemTiming(item, { sourceUrl: 'https://e.com/page.html' });
-    assert.equal('duration' in item, false);
+    assert.equal(typeof item.duration, 'number');
+    assert.ok((item.duration as number) >= 1);
+  });
+
+  test('generativeDuration config controls the stamped value', () => {
+    const prev = process.env.DEFAULT_GENERATIVE_DURATION;
+    process.env.DEFAULT_GENERATIVE_DURATION = '75';
+    try {
+      const item: Record<string, unknown> = {};
+      applyItemTiming(item, { mimeType: 'text/html', sourceUrl: 'https://e.com/art' });
+      assert.equal(item.duration, 75);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.DEFAULT_GENERATIVE_DURATION;
+      } else {
+        process.env.DEFAULT_GENERATIVE_DURATION = prev;
+      }
+    }
+  });
+
+  test('generativeDuration=0 omits duration (open-ended escape hatch)', () => {
+    const prev = process.env.DEFAULT_GENERATIVE_DURATION;
+    process.env.DEFAULT_GENERATIVE_DURATION = '0';
+    try {
+      const item: Record<string, unknown> = { display: { scaling: 'fit' } };
+      applyItemTiming(item, { mimeType: 'text/html', sourceUrl: 'https://e.com/art' });
+      assert.equal('duration' in item, false);
+      assert.deepEqual(item.display, { scaling: 'fit' });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.DEFAULT_GENERATIVE_DURATION;
+      } else {
+        process.env.DEFAULT_GENERATIVE_DURATION = prev;
+      }
+    }
   });
 });
 
@@ -154,15 +191,17 @@ describe('item builders honor auto timing', () => {
     assert.equal(item.display.loop, false);
   });
 
-  test('buildUrlItem: .html URL plays open-ended (no duration)', () => {
+  test('buildUrlItem: .html URL carries the generative duration', () => {
     const item = buildUrlItem('https://whorl.app/index_launch.html');
-    assert.equal('duration' in item, false);
+    assert.equal(typeof item.duration, 'number');
+    assert.ok(item.duration >= 1);
     assert.equal(item.display.loop, undefined);
   });
 
-  test('buildUrlItem: extensionless URL is treated as interactive web (no duration)', () => {
+  test('buildUrlItem: extensionless URL is treated as interactive web (generative duration)', () => {
     const item = buildUrlItem('https://whorl.app/output/abc123');
-    assert.equal('duration' in item, false);
+    assert.equal(typeof item.duration, 'number');
+    assert.ok(item.duration >= 1);
   });
 
   test('buildUrlItem: explicit duration still wins for an HTML page', () => {


### PR DESCRIPTION
## Problem

A customer's generative-art playlist crashed the FF1 "pretty much right away," while his image slideshow played fine. Root cause is a DP-1 `duration` contract mismatch:

- ff-cli intentionally emitted generative/interactive (HTML) works with **no `duration`** (they have no end-of-stream event), expecting the player to park open-ended.
- The FF1 app's DP-1 parser **requires** `duration` (`json['duration'] as int`), so a single duration-less item makes it throw and reject the **entire** cast. (Images carry a duration, so those playlists parse — hence the slideshow worked.)
- Even when it parses, the device already substitutes a 60s default for a missing/zero duration, so the "open-ended" intent never actually held on FF1.

## Change

Stamp generative/interactive works with a configurable **`generativeDuration`** (default **60s**, env `DEFAULT_GENERATIVE_DURATION`) so playlists rotate and parse on strict players. Set it to `0` to opt back into open-ended (omit the field). Video/audio still omit `duration` to play their natural length, and an explicit `--duration` still wins.

## Notes

- The strict-parser bug is the real fix and is handled separately in **ff-app** (tolerate a missing/null `duration`). This ff-cli change keeps **already-deployed FF1 devices** working without waiting for an app update, and gives sensible rotation timing by default.
- `npm run verify` green; tests 374 → **376** (added coverage for the `generativeDuration` knob and the `0` open-ended escape hatch; updated the interactive-timing assertions). Docs updated.
