### PR TITLE
deps: swap @feralfile/source-resolver git URL for npm registry semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,6 @@ npm run dev -- setup
 npm run dev -- find https://objkt.com/tokens/hicetnunc/111068 --play
 npm run dev -- play "https://example.com/video.mp4" --skip-verify
 ```
-
-> **npm 12+:** `npm ci`/`npm install` fail with `Fetching packages of type "git" have been disabled` because `@feralfile/source-resolver` is a git-URL dependency and npm 12 blocks those by default. Install with `npm ci --allow-git=all` until the resolver is published to the npm registry.
-
 ## Documentation
 
 - Getting started and usage: `./docs/README.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@feralfile/source-resolver": "git+https://github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
+        "@feralfile/source-resolver": "^1.0.0",
         "@napi-rs/keyring": "1.3.0",
         "axios": "^1.6.2",
         "bonjour-service": "^1.3.0",
@@ -631,8 +631,9 @@
       }
     },
     "node_modules/@feralfile/source-resolver": {
-      "version": "0.0.0",
-      "resolved": "git+https://github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@feralfile/source-resolver/-/source-resolver-1.0.0.tgz",
+      "integrity": "sha512-GPYhxNgt8EhptgIFVC5wLhHWkVuyxFAiXRldI6wCP1kDAcaos1jmqIT5l9h0XgN1H2MmzZG/sEbDRRpgAM8ZBw==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "license": "MIT",
   "dependencies": {
     "@napi-rs/keyring": "1.3.0",
-    "@feralfile/source-resolver": "git+https://github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
+    "@feralfile/source-resolver": "^1.0.0",
     "axios": "^1.6.2",
     "bonjour-service": "^1.3.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
## What

Replaces the git-URL dependency on `@feralfile/source-resolver` with `^1.0.0` from the npm registry, and removes the README `--allow-git` workaround note that this makes obsolete.

## Why

npm 12's supply-chain defaults (`allow-git=none`) refuse git-URL dependencies, which currently breaks `npm i -g @feralfile/cli` for end users on npm 12 and `npm ci` for contributors. Publishing the resolver properly fixes both without weakening npm's protections. Companion PR adding the resolver's publish pipeline: feral-file/ff-source-resolver#11.

## Draft until

1. feral-file/ff-source-resolver#11 merges and `@feralfile/source-resolver@1.0.0` is published (bootstrap steps in that PR).
2. `package-lock.json` is regenerated here with `npm install` (CI stays red on lockfile mismatch until then).

Note: `^1.0.0` is cut from resolver `main`, two merges ahead of the old commit pin — it picks up playable-artwork-source resolution and its hardening fix. ff-cli's resolver-path tests will exercise the delta once the lockfile lands.

Bundled release binaries and the curl install path are unaffected either way (esbuild inlines the dependency); this changes only npm-based installs.