### PR TITLE
feat(playlist): build DP-1 models via dp1-js builders

### DIFF
--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -105,7 +105,7 @@ Based on the code today, the CLI is responsible for:
 - resolving marketplace URLs, on-chain coordinates, and wallet addresses into playlists (`find`)
 - running feed fetches, address queries, contract-based NFT queries, domain resolution, playlist building, verification, publishing, and playback
 - supporting a deterministic build path from structured JSON (`build`)
-- building DP-1 playlist envelopes from NFT metadata or direct media URLs
+- building DP-1 playlist envelopes from NFT metadata or direct media URLs via `dp1-js` document and leaf builders (so constructed playlists stay schema-conformant)
 - validating and verifying playlist structure and signatures
 - signing playlists when a private key is configured
 - publishing validated playlists to configured feed servers

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "dotenv": "^16.3.1",
-        "dp1-js": "2.0.0",
+        "dp1-js": "2.1.0",
         "ff1": "^1.0.0",
         "fuzzysort": "^3.1.0",
         "viem": "^2.38.2"
@@ -632,7 +632,7 @@
     },
     "node_modules/@feralfile/source-resolver": {
       "version": "0.0.0",
-      "resolved": "git+https://github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
+      "resolved": "git+ssh://git@github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -1400,6 +1400,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1416,6 +1417,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1430,7 +1432,8 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1671,9 +1674,10 @@
       }
     },
     "node_modules/dp1-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dp1-js/-/dp1-js-2.0.0.tgz",
-      "integrity": "sha512-J/8HNuEsYWlzsVFSUp28pQtBNlWIaJoo83Y90DwhHVv+FSg4GR8u6xMQnwkXdjdPZPntVaBKO51ivnBO6mxjIQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dp1-js/-/dp1-js-2.1.0.tgz",
+      "integrity": "sha512-hVNTz1oKe5f3431FBe/sZ5IgoxktVUlI6qJafWqSHbhMJ7P0OXiSzBuOiN9TUVXwhdPnISw92TsvgtRgouXRrA==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
@@ -1688,6 +1692,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
       "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.2.0"
       },
@@ -1702,6 +1707,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -1713,6 +1719,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1727,7 +1734,8 @@
     "node_modules/dp1-js/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2109,9 +2117,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -2121,7 +2129,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -2918,6 +2927,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -632,7 +632,7 @@
     },
     "node_modules/@feralfile/source-resolver": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
+      "resolved": "git+https://github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@napi-rs/keyring": "1.3.0",
     "@feralfile/source-resolver": "git+https://github.com/feral-file/ff-source-resolver.git#54be943014c8cf7860114510257cdd713bbf4e79",
+    "@napi-rs/keyring": "1.3.0",
     "axios": "^1.6.2",
     "bonjour-service": "^1.3.0",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "dotenv": "^16.3.1",
-    "dp1-js": "2.0.0",
+    "dp1-js": "2.1.0",
     "ff1": "^1.0.0",
     "fuzzysort": "^3.1.0",
     "viem": "^2.38.2"

--- a/src/utilities/feed-fetcher.js
+++ b/src/utilities/feed-fetcher.js
@@ -381,6 +381,26 @@ function shuffleArray(array) {
 }
 
 /**
+ * Normalize a legacy item `provenance` block to the DP-1 schema shape.
+ *
+ * A prior `buildUrlItem` stamped off-chain URL items with
+ * `provenance: { type: 'offChainURI', uri }`, but the DP-1 ProvenanceBlock has
+ * no top-level `uri` — a `uri` only exists under `provenance.contract`. Drop the
+ * stray top-level `uri` so rebuilding a legacy feed playlist produces the same
+ * clean shape as freshly-built items; every other provenance field is preserved.
+ *
+ * @param {Object} provenance - Item provenance block (already known to be an object)
+ * @returns {Object} Provenance without a stray top-level `uri`
+ */
+function normalizeProvenance(provenance) {
+  if (!('uri' in provenance)) {
+    return provenance;
+  }
+  const { uri: _uri, ...rest } = provenance;
+  return rest;
+}
+
+/**
  * Get playlist items from a playlist
  *
  * @param {Object} playlist - DP1 playlist object
@@ -412,8 +432,17 @@ function extractPlaylistItems(playlist, quantity, duration, shuffle = true) {
   // `created` field (it lives only at the playlist level), so drop it here —
   // including from legacy feed entries that may still carry it — before the
   // items reach PlaylistBuilder for construction.
+  //
+  // Also normalize legacy `offChainURI` provenance: an earlier `buildUrlItem`
+  // emitted `provenance: { type: 'offChainURI', uri }`, but the DP-1 schema has
+  // no top-level `provenance.uri` (a `uri` only lives under `provenance.contract`).
+  // Rebuilding a legacy feed playlist would otherwise carry that stray field
+  // through PlaylistBuilder into the output, so drop it during extraction.
   items = items.map((item) => {
     const { created: _created, ...next } = item;
+    if (next.provenance && typeof next.provenance === 'object') {
+      next.provenance = normalizeProvenance(next.provenance);
+    }
     if (typeof duration === 'number') {
       next.duration = duration;
     }

--- a/src/utilities/feed-fetcher.js
+++ b/src/utilities/feed-fetcher.js
@@ -407,11 +407,13 @@ function extractPlaylistItems(playlist, quantity, duration, shuffle = true) {
   // Apply an explicit duration override when one was requested; otherwise
   // keep each item's own timing (including intentionally absent duration,
   // which DP-1 §4.1 uses for natural-length playback of video/audio).
+  //
+  // Strip any item-level `created`: the DP-1 PlaylistItem schema has no
+  // `created` field (it lives only at the playlist level), so drop it here —
+  // including from legacy feed entries that may still carry it — before the
+  // items reach PlaylistBuilder for construction.
   items = items.map((item) => {
-    const next = {
-      ...item,
-      created: item.created || new Date().toISOString(), // Ensure created field exists
-    };
+    const { created: _created, ...next } = item;
     if (typeof duration === 'number') {
       next.duration = duration;
     }

--- a/src/utilities/nft-indexer.js
+++ b/src/utilities/nft-indexer.js
@@ -4,9 +4,10 @@
  * to retrieve comprehensive token information.
  */
 
+const { PlaylistItemBuilder, ProvenanceBuilder, ContractBuilder } = require('dp1-js');
 const GRAPHQL_ENDPOINT = 'https://indexer.feralfile.com/graphql';
 const logger = require('../logger');
-const { applyItemTiming } = require('./playlist-builder');
+const { applyTimingToItemBuilder, buildDefaultDisplay } = require('./playlist-builder');
 
 // Polling configuration (in milliseconds)
 const POLLING_INTERVAL_MS = 2000; // Poll every 2 seconds
@@ -480,29 +481,42 @@ function convertToDP1Item(tokenData, duration) {
     bitmark: 'bitmark', // DP1 spec uses 'bitmark', not 'bmk'
   };
 
-  // Build DP1 item structure (strict DP1 v1.0.0 compliance)
-  const dp1Item = {
-    id: itemId,
-    source: sourceUrl,
-    license: 'open',
-    created: new Date().toISOString(),
-    provenance: {
-      type: 'onChain',
-      contract: {
-        chain: chainMap[token.chain.toLowerCase()] || 'other',
-        standard: token.standard || detectTokenStandard(token.chain, token.contractAddress),
-        address: token.contractAddress,
-        tokenId: String(token.tokenId),
-      },
-    },
-  };
+  // Build via dp1-js PlaylistItemBuilder so leaf blocks match DP-1 AJV schema.
+  const itemBuilder = new PlaylistItemBuilder()
+    .id(itemId)
+    .source(sourceUrl)
+    .license('open')
+    .provenance(
+      new ProvenanceBuilder().type('onChain').contract(
+        new ContractBuilder()
+          .chain(chainMap[token.chain.toLowerCase()] || 'other')
+          .standard(token.standard || detectTokenStandard(token.chain, token.contractAddress))
+          .address(token.contractAddress)
+          .tokenId(String(token.tokenId))
+      )
+    );
 
   // Add title if available (valid DP1 field)
   if (token.name) {
-    dp1Item.title = token.name;
+    itemBuilder.title(token.name);
   }
 
-  applyItemTiming(dp1Item, { mimeType: token.image?.mimeType, sourceUrl }, duration);
+  applyTimingToItemBuilder(
+    itemBuilder,
+    { mimeType: token.image?.mimeType, sourceUrl },
+    duration,
+    buildDefaultDisplay()
+  );
+
+  let dp1Item;
+  try {
+    dp1Item = itemBuilder.build();
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 
   logger.debug('[NFT Indexer] ✓ Converted to DP1:', {
     title: token.name,

--- a/src/utilities/playlist-builder.js
+++ b/src/utilities/playlist-builder.js
@@ -1,10 +1,27 @@
 /**
  * Playlist Builder Utilities
- * Core functions for building and validating DP1 playlists
+ *
+ * Constructs DP-1 playlists and items via dp1-js document/leaf builders so
+ * every generated object is schema-validated against the DP-1 AJV defs before
+ * optional signing. Domain timing heuristics (DP-1 §4.1) stay in this module;
+ * leaf shapes (display, provenance, contract) come from dp1-js.
  */
 
+const {
+  PlaylistBuilder,
+  PlaylistItemBuilder,
+  DisplayPrefsBuilder,
+  ProvenanceBuilder,
+  ContractBuilder,
+  ValidatePlaylist,
+  slugify: dp1Slugify,
+  generateId,
+} = require('dp1-js');
 const { getPlaylistConfig, getConfig } = require('../config');
 const { signPlaylist } = require('./playlist-signer');
+
+/** Default display background that passes DP-1 hex color validation. */
+const DEFAULT_BACKGROUND = '#111111';
 
 /**
  * isTimeBasedMedia reports whether an item's media has an intrinsic runtime
@@ -45,25 +62,44 @@ function isInteractiveWeb(mimeType, sourceUrl) {
 }
 
 /**
+ * resolveItemTiming computes duration/loop decisions per DP-1 §4.1 without
+ * mutating a playlist item. Callers stamp the result through PlaylistItemBuilder.
+ *
+ * @param {Object} mediaHints - Media signals for the time-based check
+ * @param {string} [mediaHints.mimeType] - Indexer-reported MIME type
+ * @param {string} [mediaHints.sourceUrl] - Item source URL
+ * @param {number} [duration] - Explicit display seconds; omit for auto
+ * @returns {{ duration?: number, loopFalse?: boolean }}
+ */
+function resolveItemTiming(mediaHints = {}, duration) {
+  if (typeof duration === 'number') {
+    return { duration };
+  }
+
+  if (isTimeBasedMedia(mediaHints.mimeType, mediaHints.sourceUrl)) {
+    return { loopFalse: true };
+  }
+
+  if (isInteractiveWeb(mediaHints.mimeType, mediaHints.sourceUrl)) {
+    // Generative/interactive works have no intrinsic runtime, so stamp the
+    // configured generative duration to drive playlist rotation. A configured
+    // value of 0 means "omit" — a conformant player then parks open-ended.
+    const generativeDuration = getGenerativeDuration();
+    if (generativeDuration > 0) {
+      return { duration: generativeDuration };
+    }
+    return {};
+  }
+
+  return { duration: getDefaultStaticDuration() };
+}
+
+/**
  * applyItemTiming sets a DP1 item's playback timing per DP-1 §4.1.
  *
- * Invariant this function owns: an explicit numeric `duration` always wins
- * and is stamped as-is. When `duration` is undefined/null ("auto"):
- *   - a time-based source (video/audio) gets NO duration and
- *     `display.loop: false`, so a conformant player MUST advance at
- *     end-of-stream — the media plays its natural length;
- *   - an interactive web page (HTML) — generative art with no intrinsic
- *     runtime and no end-of-stream event — gets the configured
- *     `generativeDuration` (default 60s) so the playlist rotates. Set
- *     `generativeDuration` to 0 to omit it and have a conformant player park
- *     on the work open-ended instead;
- *   - static and code-based sources fall back to the configured
- *     `defaultDuration` because they have no intrinsic runtime to play out.
- *
- * Do not stamp a duration on video/audio: it silently truncates or pads them.
- * (Earlier this also omitted duration for HTML works, which left them with no
- * duration field. Players that require the field — notably FF1 — then rejected
- * the entire playlist, so generative works now carry an explicit duration.)
+ * Kept for unit tests and callers that mutate plain objects. New construction
+ * paths prefer resolveItemTiming + PlaylistItemBuilder so the final item is
+ * schema-validated by dp1-js.
  *
  * @param {Object} item - DP1 playlist item (mutated in place)
  * @param {Object} mediaHints - Media signals for the time-based check
@@ -73,29 +109,50 @@ function isInteractiveWeb(mimeType, sourceUrl) {
  * @returns {Object} The same item, for chaining
  */
 function applyItemTiming(item, mediaHints = {}, duration) {
-  if (typeof duration === 'number') {
-    item.duration = duration;
-    return item;
+  const timing = resolveItemTiming(mediaHints, duration);
+  if (typeof timing.duration === 'number') {
+    item.duration = timing.duration;
   }
-
-  if (isTimeBasedMedia(mediaHints.mimeType, mediaHints.sourceUrl)) {
+  if (timing.loopFalse) {
     item.display = { ...(item.display || {}), loop: false };
-    return item;
   }
-
-  if (isInteractiveWeb(mediaHints.mimeType, mediaHints.sourceUrl)) {
-    // Generative/interactive works have no intrinsic runtime, so stamp the
-    // configured generative duration to drive playlist rotation. A configured
-    // value of 0 means "omit" — a conformant player then parks open-ended.
-    const generativeDuration = getGenerativeDuration();
-    if (generativeDuration > 0) {
-      item.duration = generativeDuration;
-    }
-    return item;
-  }
-
-  item.duration = getDefaultStaticDuration();
   return item;
+}
+
+/**
+ * buildDefaultDisplay builds schema-valid DisplayPrefs via dp1-js.
+ *
+ * @param {{ loopFalse?: boolean }} [opts]
+ * @returns {object} Validated DisplayPrefs
+ */
+function buildDefaultDisplay(opts = {}) {
+  const builder = new DisplayPrefsBuilder().scaling('fit').background(DEFAULT_BACKGROUND).margin(0);
+  if (opts.loopFalse) {
+    builder.loop(false);
+  }
+  return builder.build();
+}
+
+/**
+ * applyTimingToItemBuilder stamps resolveItemTiming results onto a builder.
+ *
+ * @param {InstanceType<typeof PlaylistItemBuilder>} itemBuilder
+ * @param {Object} mediaHints
+ * @param {number} [duration]
+ * @param {object} [baseDisplay] - Already-built DisplayPrefs without loop
+ * @returns {InstanceType<typeof PlaylistItemBuilder>}
+ */
+function applyTimingToItemBuilder(itemBuilder, mediaHints, duration, baseDisplay) {
+  const timing = resolveItemTiming(mediaHints, duration);
+  if (typeof timing.duration === 'number') {
+    itemBuilder.durationSeconds(timing.duration);
+  }
+  if (timing.loopFalse) {
+    itemBuilder.display(buildDefaultDisplay({ loopFalse: true }));
+  } else if (baseDisplay) {
+    itemBuilder.display(baseDisplay);
+  }
+  return itemBuilder;
 }
 
 /**
@@ -131,27 +188,22 @@ function getGenerativeDuration() {
 }
 
 /**
- * Convert a string to a URL-friendly slug
- *
- * Lowercases, trims, replaces whitespace with dashes, and strips invalid chars.
- * Falls back to a short id when input is empty.
+ * slugify converts free text to a kebab-case slug via dp1-js.
+ * Falls back to a short id when input is empty (dp1-js slugify throws then).
  *
  * @param {string} value - Source string to slugify
  * @returns {string} Slugified string
  */
 function slugify(value) {
-  const base = (value || '').toString().trim().toLowerCase();
+  const base = (value || '').toString().trim();
   if (!base) {
-    const crypto = require('crypto');
-    return `playlist-${crypto.randomUUID().split('-')[0]}`;
+    return `playlist-${generateId().split('-')[0]}`;
   }
-  return base
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '') // strip diacritics
-    .replace(/[^a-z0-9\s-]/g, '') // remove invalid chars
-    .replace(/\s+/g, '-') // spaces -> dashes
-    .replace(/-+/g, '-') // collapse dashes
-    .replace(/^-|-$/g, ''); // trim dashes
+  try {
+    return dp1Slugify(base);
+  } catch (_error) {
+    return `playlist-${generateId().split('-')[0]}`;
+  }
 }
 
 /**
@@ -203,46 +255,38 @@ function convertTokenToDP1ItemSingle(tokenInfo, duration) {
   };
   const standard = standardMap[token.standard?.toLowerCase()] || 'other';
 
-  // Generate unique ID for the item (UUID v4 format)
-  const crypto = require('crypto');
-  const itemId = crypto.randomUUID();
+  const contractBuilder = new ContractBuilder()
+    .chain(chain)
+    .standard(standard)
+    .address(token.contractAddress)
+    .tokenId(String(token.tokenId));
 
-  // Build DP1 item structure according to OpenAPI spec
-  const dp1Item = {
-    id: itemId,
-    title: token.name || `Token #${token.tokenId}`,
-    source: sourceUrl,
-    license: 'token', // NFTs are token-gated by default
-    created: new Date().toISOString(),
-    provenance: {
-      type: 'onChain',
-      contract: {
-        chain: chain,
-        standard: standard,
-        address: token.contractAddress,
-        tokenId: String(token.tokenId),
-      },
-    },
-  };
-
-  // Add display preferences if available
-  dp1Item.display = {
-    scaling: 'fit',
-    background: '#111',
-    margin: 0,
-  };
-
-  // Add metadata URI if available
-  if (token.metadata?.uri || token.tokenURI) {
-    dp1Item.provenance.contract.uri = token.metadata?.uri || token.tokenURI;
+  // Add metadata URI if available (contract.uri is the DP-1 field)
+  const metadataUri = token.metadata?.uri || token.tokenURI;
+  if (metadataUri) {
+    contractBuilder.uri(metadataUri);
   }
+
+  const itemBuilder = new PlaylistItemBuilder()
+    .id(generateId())
+    .title(token.name || `Token #${token.tokenId}`)
+    .source(sourceUrl)
+    .license('token')
+    .provenance(new ProvenanceBuilder().type('onChain').contract(contractBuilder));
 
   // Add reference to image if animation_url was used as source
   if ((token.animation_url || token.animationUrl) && (token.image?.url || token.image)) {
-    dp1Item.ref = token.image?.url || token.image;
+    itemBuilder.ref(token.image?.url || token.image);
   }
 
-  return applyItemTiming(dp1Item, { mimeType: token.image?.mimeType, sourceUrl }, duration);
+  applyTimingToItemBuilder(
+    itemBuilder,
+    { mimeType: token.image?.mimeType, sourceUrl },
+    duration,
+    buildDefaultDisplay()
+  );
+
+  return itemBuilder.build();
 }
 
 /**
@@ -365,10 +409,11 @@ function generatePlaylistTitle(items) {
 }
 
 /**
- * Build complete DP1 v1.0.0 compliant playlist
+ * Build a complete DP-1 v1.1.0 playlist via PlaylistBuilder.
  *
- * Creates a complete playlist structure with metadata, defaults, and optional signature.
- * Supports both object parameter and legacy separate parameters for backward compatibility.
+ * Creates a schema-validated unsigned playlist, then optionally signs when a
+ * private key is configured. Supports both object parameter and legacy
+ * separate parameters.
  *
  * @param {Object|Array} paramsOrItems - Playlist parameters object or items array (legacy)
  * @param {Array} [paramsOrItems.items] - Array of DP1 items
@@ -397,7 +442,7 @@ function generatePlaylistTitle(items) {
  *   title: 'Test',
  *   deterministicMode: true,
  *   fixedTimestamp: '2024-01-01T00:00:00.000Z',
- *   fixedId: 'playlist_test_123'
+ *   fixedId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
  * });
  */
 async function buildDP1Playlist(paramsOrItems, options = {}) {
@@ -418,7 +463,7 @@ async function buildDP1Playlist(paramsOrItems, options = {}) {
     ({ title, slug, deterministicMode, fixedTimestamp, fixedId } = options);
   }
 
-  // Validate items
+  // Validate items early (PlaylistBuilder also rejects empty items without dynamicQuery)
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error('Playlist must contain at least one item');
   }
@@ -445,34 +490,28 @@ async function buildDP1Playlist(paramsOrItems, options = {}) {
     slug = slugify(title);
   }
 
-  // Build DP1 playlist structure using the v1.1.0 envelope.
-  // Support deterministic mode for testing (freeze timestamp and ID)
-  const timestamp = deterministicMode && fixedTimestamp ? fixedTimestamp : new Date().toISOString();
-  const crypto = require('crypto');
-  const playlistId = deterministicMode && fixedId ? fixedId : crypto.randomUUID();
+  // Build DP1 playlist structure using the v1.1.0 envelope via dp1-js.
+  // Support deterministic mode for testing (freeze timestamp and ID).
+  // No defaults.duration: items that should be timed carry an explicit
+  // duration already, and a playlist-level default would make conformant
+  // players time-cut items that intentionally omit duration to play
+  // their natural length (DP-1 §4.1 end-of-stream advance).
+  const playlistBuilder = new PlaylistBuilder()
+    .dpVersion('1.1.0')
+    .title(title)
+    .slug(slug)
+    .defaultDisplay(buildDefaultDisplay())
+    .defaultLicense('token')
+    .items(items);
 
-  const playlist = {
-    dpVersion: '1.1.0',
-    id: playlistId,
-    title,
-    created: timestamp,
-    items,
-    defaults: {
-      display: {
-        scaling: 'fit',
-        background: '#111',
-        margin: 0,
-      },
-      license: 'token',
-      // No defaults.duration: items that should be timed carry an explicit
-      // duration already, and a playlist-level default would make conformant
-      // players time-cut items that intentionally omit duration to play
-      // their natural length (DP-1 §4.1 end-of-stream advance).
-    },
-  };
+  if (deterministicMode && fixedId) {
+    playlistBuilder.id(fixedId);
+  }
+  if (deterministicMode && fixedTimestamp) {
+    playlistBuilder.created(fixedTimestamp);
+  }
 
-  // Always include slug (auto-generated when missing)
-  playlist.slug = slug;
+  const playlist = playlistBuilder.build();
 
   // Sign the playlist if private key is configured.
   try {
@@ -490,10 +529,10 @@ async function buildDP1Playlist(paramsOrItems, options = {}) {
 }
 
 /**
- * Validate DP1 playlist structure according to OpenAPI spec
+ * validateDP1Playlist schema-validates a playlist via dp1-js ValidatePlaylist.
  *
- * Performs comprehensive validation of playlist structure, fields, and item requirements.
- * Returns detailed errors for each validation failure.
+ * Unsigned drafts are accepted (`requireSignatures: false`). Returns the
+ * historical `{ valid, errors }` shape for CLI/tests.
  *
  * @param {Object} playlist - DP1 playlist to validate
  * @returns {Object} Validation result
@@ -506,88 +545,21 @@ async function buildDP1Playlist(paramsOrItems, options = {}) {
  * }
  */
 function validateDP1Playlist(playlist) {
-  const errors = [];
-
-  // Check required playlist fields
-  if (!playlist.dpVersion) {
-    errors.push('Missing required field: dpVersion');
-  } else if (typeof playlist.dpVersion !== 'string') {
-    errors.push('Field "dpVersion" must be a string');
+  try {
+    ValidatePlaylist(playlist, { requireSignatures: false });
+    return { valid: true, errors: [] };
+  } catch (error) {
+    const details = Array.isArray(error?.details) ? error.details : [];
+    const errors =
+      details.length > 0
+        ? details.map((detail) => {
+            const path = detail?.path ? String(detail.path) : '/';
+            const message = detail?.message ? String(detail.message) : 'validation failed';
+            return `${path}: ${message}`;
+          })
+        : [error instanceof Error ? error.message : String(error)];
+    return { valid: false, errors };
   }
-
-  if (!playlist.title) {
-    errors.push('Missing required field: title');
-  } else if (playlist.title.length > 256) {
-    errors.push('Field "title" must not exceed 256 characters');
-  }
-
-  if (!playlist.items) {
-    errors.push('Missing required field: items');
-  } else if (!Array.isArray(playlist.items)) {
-    errors.push('Field "items" must be an array');
-  } else if (playlist.items.length === 0) {
-    errors.push('Playlist must contain at least one item');
-  } else if (playlist.items.length > 1024) {
-    errors.push('Playlist cannot contain more than 1024 items');
-  } else {
-    // Validate each item according to PlaylistItem schema
-    playlist.items.forEach((item, index) => {
-      if (!item.source) {
-        errors.push(`Item ${index}: Missing required field "source"`);
-      } else if (typeof item.source !== 'string') {
-        errors.push(`Item ${index}: Field "source" must be a string (URI)`);
-      }
-
-      // Duration is OPTIONAL per the DP-1 v1.1.0 schema (PlaylistItem requires
-      // only `source`; duration has `minimum: 0`). Absent duration is meaningful:
-      // time-based sources advance at end-of-stream (§4.1). Do not tighten this
-      // back to required — it would reject spec-valid playlists.
-      if (item.duration !== undefined && item.duration !== null) {
-        if (typeof item.duration !== 'number' || item.duration < 0) {
-          errors.push(`Item ${index}: Field "duration" must be a number >= 0`);
-        }
-      }
-
-      if (!item.license) {
-        errors.push(`Item ${index}: Missing required field "license"`);
-      } else if (!['open', 'token', 'subscription'].includes(item.license)) {
-        errors.push(`Item ${index}: Field "license" must be one of: open, token, subscription`);
-      }
-
-      // Validate optional title length
-      if (item.title && item.title.length > 256) {
-        errors.push(`Item ${index}: Field "title" must not exceed 256 characters`);
-      }
-
-      // Validate optional provenance structure
-      if (item.provenance) {
-        if (!item.provenance.type) {
-          errors.push(`Item ${index}: provenance.type is required when provenance is present`);
-        } else if (!['onChain', 'seriesRegistry', 'offChainURI'].includes(item.provenance.type)) {
-          errors.push(
-            `Item ${index}: provenance.type must be one of: onChain, seriesRegistry, offChainURI`
-          );
-        }
-
-        if (item.provenance.contract) {
-          if (!item.provenance.contract.chain) {
-            errors.push(`Item ${index}: provenance.contract.chain is required`);
-          } else if (
-            !['evm', 'tezos', 'bitmark', 'other'].includes(item.provenance.contract.chain)
-          ) {
-            errors.push(
-              `Item ${index}: provenance.contract.chain must be one of: evm, tezos, bitmark, other`
-            );
-          }
-        }
-      }
-    });
-  }
-
-  return {
-    valid: errors.length === 0,
-    errors,
-  };
 }
 
 /**
@@ -653,7 +625,7 @@ function detectMimeType(url) {
 }
 
 /**
- * Build a single DP1 playlist item from a URL
+ * Build a single DP1 playlist item from a URL via PlaylistItemBuilder.
  *
  * @param {string} url - Media URL
  * @param {number} [duration] - Explicit display seconds; omit for auto timing
@@ -691,25 +663,13 @@ function buildUrlItem(url, duration, options = {}) {
     }
   }
 
-  const crypto = require('crypto');
-  const itemId = crypto.randomUUID();
-
-  const item = {
-    id: itemId,
-    title,
-    source: sourceUrl,
-    license: 'open',
-    created: new Date().toISOString(),
-    provenance: {
-      type: 'offChainURI',
-      uri: sourceUrl,
-    },
-    display: {
-      scaling: 'fit',
-      background: '#111',
-      margin: 0,
-    },
-  };
+  const itemBuilder = new PlaylistItemBuilder()
+    .id(generateId())
+    .title(title)
+    .source(sourceUrl)
+    .license('open')
+    // offChainURI has no provenance.uri in the DP-1 schema — only type.
+    .provenance(new ProvenanceBuilder().type('offChainURI'));
 
   // A URL handed to `play` that isn't a recognized media file is treated as an
   // interactive web page: the FF1 renders unknown URLs in a sandboxed iframe,
@@ -718,7 +678,14 @@ function buildUrlItem(url, duration, options = {}) {
   // instead of the static-image default.
   const mimeHint = options.mimeType || (detectMimeType(sourceUrl) === '' ? 'text/html' : undefined);
 
-  return applyItemTiming(item, { sourceUrl, mimeType: mimeHint }, duration);
+  applyTimingToItemBuilder(
+    itemBuilder,
+    { sourceUrl, mimeType: mimeHint },
+    duration,
+    buildDefaultDisplay()
+  );
+
+  return itemBuilder.build();
 }
 
 module.exports = {
@@ -732,5 +699,8 @@ module.exports = {
   isTimeBasedMedia,
   isInteractiveWeb,
   applyItemTiming,
+  resolveItemTiming,
+  applyTimingToItemBuilder,
   buildUrlItem,
+  buildDefaultDisplay,
 };

--- a/tests/feed-extract-created.test.ts
+++ b/tests/feed-extract-created.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `fetch_feed` → `buildDP1Playlist` path: item-level `created` must be dropped.
+ *
+ * The DP-1 v1.1.0 PlaylistItem schema has no `created` field — `created` is a
+ * playlist-level timestamp only. Feed playlists can carry a legacy item-level
+ * `created`, so `extractPlaylistItems` must strip it before the items reach
+ * PlaylistBuilder, otherwise the built playlist carries a non-schema field.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { extractPlaylistItems } = require('../src/utilities/feed-fetcher.js');
+const { buildDP1Playlist, validateDP1Playlist } = require('../src/utilities/playlist-builder.js');
+
+/** A feed playlist whose items still carry a legacy item-level `created`. */
+function feedPlaylistWithCreated() {
+  return {
+    id: 'feed-playlist-1',
+    title: 'Feed Playlist',
+    created: '2024-01-01T00:00:00.000Z',
+    items: [
+      {
+        source: 'https://example.com/artwork-1.html',
+        title: 'Artwork 1',
+        duration: 300,
+        created: '2024-02-02T00:00:00.000Z',
+      },
+      {
+        source: 'https://example.com/artwork-2.html',
+        title: 'Artwork 2',
+        created: '2024-03-03T00:00:00.000Z',
+      },
+    ],
+  };
+}
+
+describe('extractPlaylistItems drops item-level created', () => {
+  test('strips `created` from every extracted feed item', () => {
+    const items = extractPlaylistItems(feedPlaylistWithCreated(), 10, undefined, false);
+
+    assert.equal(items.length, 2);
+    for (const item of items) {
+      assert.equal('created' in item, false, 'extracted item must not carry `created`');
+    }
+    // Other item fields are preserved.
+    assert.equal(items[0].source, 'https://example.com/artwork-1.html');
+    assert.equal(items[0].duration, 300);
+    assert.equal(items[1].title, 'Artwork 2');
+  });
+
+  test('extracted feed items build a schema-valid DP-1 playlist', async () => {
+    const items = extractPlaylistItems(feedPlaylistWithCreated(), 10, undefined, false);
+    const playlist = await buildDP1Playlist({ items, title: 'From Feed' });
+
+    // No item-level `created` survives into the built playlist.
+    for (const item of playlist.items) {
+      assert.equal('created' in item, false, 'built playlist item must not carry `created`');
+    }
+
+    const result = validateDP1Playlist(playlist);
+    assert.equal(result.valid, true, `expected valid playlist, got: ${result.errors.join('; ')}`);
+  });
+});

--- a/tests/feed-extract-created.test.ts
+++ b/tests/feed-extract-created.test.ts
@@ -64,3 +64,63 @@ describe('extractPlaylistItems drops item-level created', () => {
     assert.equal(result.valid, true, `expected valid playlist, got: ${result.errors.join('; ')}`);
   });
 });
+
+/**
+ * A legacy feed playlist whose off-chain URL items carry BOTH an item-level
+ * `created` and the old `provenance: { type: 'offChainURI', uri }` shape that a
+ * prior `buildUrlItem` produced. The DP-1 ProvenanceBlock has no top-level
+ * `uri` (a `uri` only lives under `provenance.contract`), so extraction must
+ * drop it before the items reach PlaylistBuilder.
+ */
+function feedPlaylistWithLegacyOffChainURI() {
+  return {
+    id: 'feed-playlist-2',
+    title: 'Legacy Feed Playlist',
+    created: '2024-01-01T00:00:00.000Z',
+    items: [
+      {
+        source: 'https://example.com/legacy-1.html',
+        title: 'Legacy 1',
+        duration: 300,
+        created: '2024-02-02T00:00:00.000Z',
+        provenance: { type: 'offChainURI', uri: 'https://example.com/legacy-1.html' },
+      },
+    ],
+  };
+}
+
+describe('extractPlaylistItems normalizes legacy offChainURI provenance', () => {
+  test('strips both `created` and the stray `provenance.uri`', () => {
+    const items = extractPlaylistItems(feedPlaylistWithLegacyOffChainURI(), 10, undefined, false);
+
+    assert.equal(items.length, 1);
+    const [item] = items;
+    assert.equal('created' in item, false, 'extracted item must not carry `created`');
+    assert.ok(item.provenance, 'provenance is preserved');
+    assert.equal(item.provenance.type, 'offChainURI', 'provenance.type is preserved');
+    assert.equal(
+      'uri' in item.provenance,
+      false,
+      'stray top-level `provenance.uri` must be removed'
+    );
+  });
+
+  test('rebuilds a legacy feed playlist that validates and has no stray uri', async () => {
+    const items = extractPlaylistItems(feedPlaylistWithLegacyOffChainURI(), 10, undefined, false);
+    const playlist = await buildDP1Playlist({ items, title: 'From Legacy Feed' });
+
+    for (const item of playlist.items) {
+      assert.equal('created' in item, false, 'built item must not carry `created`');
+      if (item.provenance) {
+        assert.equal(
+          'uri' in item.provenance,
+          false,
+          'built item provenance must not carry a top-level `uri`'
+        );
+      }
+    }
+
+    const result = validateDP1Playlist(playlist);
+    assert.equal(result.valid, true, `expected valid playlist, got: ${result.errors.join('; ')}`);
+  });
+});

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -784,13 +784,14 @@ describe('buildRasterMediaItems', () => {
     const items = buildRasterMediaItems(tokens, series) as Array<{
       title: string;
       source: string;
-      provenance: { type: string; uri: string };
+      provenance: { type: string; uri?: string };
     }>;
     assert.equal(items.length, 2);
     assert.equal(items[0].title, 'Split Logic #1');
     assert.equal(items[0].source, 'https://media/1.mp4');
     assert.equal(items[0].provenance.type, 'offChainURI');
-    assert.equal(items[0].provenance.uri, 'https://media/1.mp4');
+    // DP-1 ProvenanceBlock has no `uri` field for offChainURI — only type/contract/dependencies.
+    assert.equal(items[0].provenance.uri, undefined);
     assert.equal(items[1].title, 'Split Logic #94');
   });
 

--- a/tests/playlist-builder-sign-v11.test.ts
+++ b/tests/playlist-builder-sign-v11.test.ts
@@ -34,7 +34,6 @@ const minimalItem = {
   source: 'https://example.com/art.mp4',
   duration: 10,
   license: 'token',
-  created: '2026-06-01T12:00:00.000Z',
 };
 
 describe('buildDP1Playlist signing (v1.1.0)', () => {

--- a/tests/playlist-item-timing.test.ts
+++ b/tests/playlist-item-timing.test.ts
@@ -282,4 +282,50 @@ describe('playlist-level conformance', () => {
     });
     assert.equal('duration' in playlist.defaults, false);
   });
+
+  test('buildUrlItem and buildDP1Playlist emit schema-valid DP-1 shapes', async () => {
+    const { ValidatePlaylist } = require('dp1-js');
+    const item = buildUrlItem('https://example.com/art.png');
+    assert.equal(item.display.background, '#111111');
+    assert.equal(item.created, undefined);
+    assert.equal(item.provenance.type, 'offChainURI');
+    assert.equal(item.provenance.uri, undefined);
+
+    const playlist = await buildDP1Playlist({
+      items: [item],
+      title: 'Schema check',
+      slug: 'schema-check',
+      deterministicMode: true,
+      fixedTimestamp: '2026-06-01T12:00:00.000Z',
+      fixedId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+    assert.equal(playlist.defaults.display.background, '#111111');
+    assert.doesNotThrow(() => ValidatePlaylist(playlist, { requireSignatures: false }));
+  });
+
+  test('NFT converters emit schema-valid on-chain items without deprecated fields', () => {
+    const { ValidatePlaylistItem } = require('dp1-js');
+    const fromBuilder = convertTokenToDP1ItemSingle(tokenInfo());
+    assert.equal(fromBuilder.created, undefined);
+    assert.equal(fromBuilder.display.background, '#111111');
+    assert.equal(fromBuilder.provenance.type, 'onChain');
+    assert.doesNotThrow(() => ValidatePlaylistItem(fromBuilder));
+
+    const fromIndexer = nftIndexer.convertToDP1Item(tokenInfo());
+    assert.equal(fromIndexer.success, true);
+    assert.equal(fromIndexer.item.created, undefined);
+    assert.equal(fromIndexer.item.display.background, '#111111');
+    assert.doesNotThrow(() => ValidatePlaylistItem(fromIndexer.item));
+  });
+
+  test('validateDP1Playlist maps AJV failures to path: message strings', () => {
+    const result = validateDP1Playlist({
+      dpVersion: '1.1.0',
+      title: 'Bad duration',
+      items: [{ source: 'https://example.com/a.png', license: 'open', duration: -1 }],
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length >= 1);
+    assert.match(result.errors[0], /: /);
+  });
 });


### PR DESCRIPTION
## Summary
- Construct playlists and items with `dp1-js` `PlaylistBuilder` / `PlaylistItemBuilder` and leaf builders instead of hand-rolled objects
- Align generated shapes with the DP-1 schema (`#111111` backgrounds, no item-level `created`, no invalid `provenance.uri` on `offChainURI`)
- Keep FF1 §4.1 timing heuristics, stamp them through builders before `build()`, then sign as before

## Notes
- Local `file:../dp1-js` dependency is intentionally **not** included in this PR; CI still expects a published `dp1-js` that exports these builders
- Bump/`dp1-js` publish should land before merge if registry `2.0.0` lacks the builders

## Test plan
- [x] `npm run verify`
- [ ] Create a playlist via `build` / `find` / URL play path and confirm output validates with `ff-cli validate`
- [ ] Confirm signed playlists still verify after builder-based construction
- [ ] After `dp1-js` builders are on npm, bump the dependency and re-run CI


Made with [Cursor](https://cursor.com)
