### PR TITLE
fix(play): probe discovery-claimed URLs as DP-1 documents before redirecting to find

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -2,7 +2,12 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { parseFindInput } from '@feralfile/source-resolver';
 import { getConfig } from '../config';
-import { isPlaylistSourceUrl, resolvePlaySource } from '../utilities/playlist-source';
+import {
+  isPlaylistSourceUrl,
+  loadPlaylistSource,
+  resolvePlaySource,
+  type PlaySource,
+} from '../utilities/playlist-source';
 import { castPlaylist } from '../utilities/playlist-cast';
 import {
   printPlaylistSourceLoadFailure,
@@ -60,6 +65,46 @@ export function describeDiscoveryInput(source: string): string | null {
   }
 }
 
+/**
+ * probeDiscoveryUrlAsPlaylist loads a discovery-classified http(s) URL as a
+ * DP-1 playlist document, or returns null when it is not one.
+ *
+ * The discovery parser claims whole hosts — any *.feralfile.com URL parses
+ * as a Feral File URL, and non-exhibition paths come back `unsupported` —
+ * which wrongly redirected DP-1 feed playlist URLs
+ * (https://feed.feralfile.com/api/v1/playlists/{slug}, exactly the URLs the
+ * feed hands out) to `find`, which has no feed route either; the documented
+ * "hosted playlist URL plays directly" contract was unreachable for them
+ * (found 2026-08-02 casting a published playlist to an FF1).
+ *
+ * Probing the document keeps both behaviors without a host allowlist: a URL
+ * that serves DP-1 JSON (`dpVersion` marker) plays directly; a marketplace
+ * *page* fails the probe (non-JSON, or JSON with no marker) and still
+ * redirects to `find` instead of being wrapped as a web item. The probe
+ * costs one fetch before a redirect, only for discovery inputs that are
+ * http(s) URLs; coordinates and wallet addresses never hit the network.
+ */
+export async function probeDiscoveryUrlAsPlaylist(source: string): Promise<PlaySource | null> {
+  if (!isPlaylistSourceUrl(source)) {
+    return null;
+  }
+  try {
+    const loaded = await loadPlaylistSource(source);
+    const document = loaded.playlist as { dpVersion?: unknown };
+    if (typeof document?.dpVersion !== 'string') {
+      return null;
+    }
+    return {
+      kind: 'playlist',
+      playlist: loaded.playlist,
+      sourceType: loaded.sourceType,
+      source: loaded.source,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export const playCommand = new Command('play')
   .description('Play a playlist or media URL on an FF1 device')
   .argument('<source>', 'Playlist file, playlist URL, or media URL')
@@ -73,8 +118,15 @@ export const playCommand = new Command('play')
       // `play` casts an exact playable source. A marketplace URL / on-chain
       // coords / wallet must be resolved through the indexer first — redirect
       // to `find` rather than silently wrapping the *page* as a web item.
+      // Exception: a discovery-classified URL that actually serves a DP-1
+      // playlist document (the discovery parser claims whole hosts, catching
+      // feed playlist URLs) plays directly — see probeDiscoveryUrlAsPlaylist.
       const discovery = describeDiscoveryInput(source);
+      let probed: PlaySource | null = null;
       if (discovery) {
+        probed = await probeDiscoveryUrlAsPlaylist(source);
+      }
+      if (discovery && !probed) {
         console.error(
           chalk.red(
             '\n`play` casts an exact playlist or media URL — it does not search marketplaces.'
@@ -91,7 +143,7 @@ export const playCommand = new Command('play')
       const config = getConfig();
       // No explicit duration: a direct video/audio URL plays its natural
       // length (DP-1 §4.1); static media uses config.defaultDuration.
-      const resolved = await resolvePlaySource(source);
+      const resolved = probed ?? (await resolvePlaySource(source));
       const isPlaylistSource = resolved.kind === 'playlist';
       const sourceLabel = isPlaylistSource
         ? `${resolved.sourceType}: ${resolved.source}`

--- a/tests/play-feed-playlist-url.test.ts
+++ b/tests/play-feed-playlist-url.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `play` accepts DP-1 feed playlist URLs that the discovery parser claims.
+ *
+ * The discovery parser claims whole hosts — any *.feralfile.com URL parses
+ * as a Feral File URL, and non-exhibition paths come back `unsupported` —
+ * which wrongly redirected DP-1 feed playlist URLs
+ * (https://feed.feralfile.com/api/v1/playlists/{slug}, exactly the URLs the
+ * feed hands out) to `find`, which has no feed route either. The documented
+ * "hosted playlist URL plays directly" contract was unreachable for them.
+ *
+ * probeDiscoveryUrlAsPlaylist pins the repair: a discovery-classified URL
+ * that actually serves a DP-1 document (dpVersion marker) resolves as a
+ * playlist; anything else still redirects to `find` — a marketplace *page*
+ * must never be wrapped as a web item.
+ */
+import assert from 'node:assert/strict';
+import { describe, test, afterEach } from 'node:test';
+import { describeDiscoveryInput, probeDiscoveryUrlAsPlaylist } from '../src/commands/play';
+
+const FEED_URL = 'https://feed.feralfile.com/api/v1/playlists/scott-night-91aa';
+
+const feedPlaylist = {
+  dpVersion: '1.1.0',
+  id: '91aa260a-a71c-4a29-8f9a-000000000000',
+  title: 'Scott — Night',
+  items: [
+    {
+      id: 'item-1',
+      title: 'item one',
+      source: 'https://example.com/a.html',
+      duration: 300,
+      license: 'open',
+    },
+  ],
+};
+
+function mockFetchOnce(body: string, status = 200): void {
+  global.fetch = (async () =>
+    new Response(body, {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+}
+
+describe('probeDiscoveryUrlAsPlaylist — feed playlist URLs play directly', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('the feed URL shape is still discovery-classified (why the probe exists)', () => {
+    // If the discovery parser ever learns feed URLs, this pin fails and the
+    // probe can likely be deleted — that is the desired outcome, not a bug.
+    assert.notEqual(describeDiscoveryInput(FEED_URL), null);
+  });
+
+  test('a discovery-claimed URL serving a DP-1 document resolves as a playlist', async () => {
+    mockFetchOnce(JSON.stringify(feedPlaylist));
+
+    const resolved = await probeDiscoveryUrlAsPlaylist(FEED_URL);
+    assert.ok(resolved);
+    assert.equal(resolved.kind, 'playlist');
+    if (resolved.kind === 'playlist') {
+      assert.equal(resolved.sourceType, 'url');
+      assert.equal(resolved.source, FEED_URL);
+      assert.equal(resolved.playlist.title, 'Scott — Night');
+    }
+  });
+
+  test('a marketplace page (non-JSON) fails the probe and keeps redirecting', async () => {
+    mockFetchOnce('<html><body>collection page</body></html>');
+
+    assert.equal(await probeDiscoveryUrlAsPlaylist(FEED_URL), null);
+  });
+
+  test('JSON without a dpVersion marker fails the probe', async () => {
+    mockFetchOnce(JSON.stringify({ items: [], hello: 'world' }));
+
+    assert.equal(await probeDiscoveryUrlAsPlaylist(FEED_URL), null);
+  });
+
+  test('an HTTP error fails the probe', async () => {
+    mockFetchOnce('not found', 404);
+
+    assert.equal(await probeDiscoveryUrlAsPlaylist(FEED_URL), null);
+  });
+
+  test('non-URL discovery inputs are never probed', async () => {
+    // A wallet address must redirect to `find` without any network call.
+    global.fetch = (async () => {
+      throw new Error('probe must not fetch for non-URL inputs');
+    }) as unknown as typeof fetch;
+
+    assert.equal(
+      await probeDiscoveryUrlAsPlaylist('0xf3860788d1597cecf938424baabe976fac87dc26'),
+      null
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`ff-cli play https://feed.feralfile.com/api/v1/playlists/<slug>` refuses with *"looks like a marketplace URL"* and redirects to `find` — which has no feed route either, so the documented "hosted playlist URL plays directly" contract is unreachable for exactly the URLs the feed hands out. Root cause: the discovery parser claims whole hosts (any `*.feralfile.com` URL parses as a Feral File URL; non-exhibition paths return `unsupported`), and `play` runs the discovery redirect before ever trying the URL as a playlist source. Likely a leftover from folding `send` into `play`: the marketplace gate came in front of the playlist-URL path and shadowed it.

## Fix

`probeDiscoveryUrlAsPlaylist`: a discovery-classified http(s) URL is loaded as a playlist document first — if it serves DP-1 JSON (`dpVersion` marker) it plays directly; anything else (marketplace *page*, non-JSON, JSON without the marker, HTTP error) fails the probe and redirects to `find` exactly as before, so a collection page is still never wrapped as a web item. No host allowlist to maintain; non-URL discovery inputs (coordinates, wallets) never hit the network.

## Verification

- 6 new tests pin the probe (`tests/play-feed-playlist-url.test.ts`), including a pin that the feed URL shape is still discovery-classified — if the parser ever learns feed URLs, that test failing signals the probe can be deleted.
- Full suite: 467/467 pass; lint clean; `tsc` clean.
- Real end-to-end: `node dist/index.js play "https://feed.feralfile.com/api/v1/playlists/scott-night-91aa" -d kkjw7j95 --skip-verify` → ✓ Playing (skip-verify pending the eip191 verifier gap, #103).