### PR TITLE
fix(deps): bump dp1-js to 2.2.0 to fix EIP-191 verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "dotenv": "^16.3.1",
-        "dp1-js": "2.1.0",
+        "dp1-js": "2.2.0",
         "ff1": "^1.0.0",
         "fuzzysort": "^3.1.0",
         "viem": "^2.38.2"
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/dp1-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dp1-js/-/dp1-js-2.1.0.tgz",
-      "integrity": "sha512-hVNTz1oKe5f3431FBe/sZ5IgoxktVUlI6qJafWqSHbhMJ7P0OXiSzBuOiN9TUVXwhdPnISw92TsvgtRgouXRrA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dp1-js/-/dp1-js-2.2.0.tgz",
+      "integrity": "sha512-WivZeOU1L7AJyLQXlgH3RY3deRSRQ8gHpPDXRZMJmVsQtbW6ogsXEKUViTi0mBPBbm0mFxgRHAqU/MbO3geKEA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@napi-rs/keyring": "1.3.0",
     "@feralfile/source-resolver": "^1.0.0",
+    "@napi-rs/keyring": "1.3.0",
     "axios": "^1.6.2",
     "bonjour-service": "^1.3.0",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "dotenv": "^16.3.1",
-    "dp1-js": "2.1.0",
+    "dp1-js": "2.2.0",
     "ff1": "^1.0.0",
     "fuzzysort": "^3.1.0",
     "viem": "^2.38.2"


### PR DESCRIPTION
Fixes #103

## Problem
`ff-cli verify` failed on every playlist carrying an EIP-191 (wallet) signature, while the reference `dp1-cli` verified the same documents cleanly.

Root cause was in the dependency, not in ff-cli: dp1-js 2.1.0's `Eip191Verifier` fed the raw 65-byte signature to noble's `recoverPublicKey`, which parses noble's own `recovery || r || s` layout (recovery byte **first**). Wallets (`personal_sign` / `eth_sign`) and `dp1-go` use the Ethereum-standard `r(32) || s(32) || v(1)` with `v` **last**. Verification therefore threw `invalid recovery id` on every wallet signature.

Fixed upstream in [display-protocol/dp1-js#16](https://github.com/display-protocol/dp1-js/pull/16), released as [dp1-js 2.2.0](https://github.com/display-protocol/dp1-js/releases/tag/v2.2.0).

## Change
A one-line dependency bump, `2.1.0` → `2.2.0`. No ff-cli source changes are needed — the CLI already delegates to dp1-js `verifyPlaylist`, and it signs only via `SignMultiEd25519`, which the upstream wire-format change does not touch.

`npm pkg set` also re-sorted `dependencies` alphabetically (`@napi-rs/keyring` was out of order). That is npm's own normalization; kept so it does not resurface as churn on the next install.

## Verification
`ff-cli verify` against the two real production documents from the issue, run from this build:

```
$ ff-cli verify .../publisher-smoke-2026-07-30-c9b5144c     # the issue's repro doc
Playlist is valid
  Signatures: 2                                              # exit 0

$ ff-cli verify .../feral-file-daily-f77fe04c
Playlist is valid
  Signatures: 2                                              # exit 0
```

Both previously reported `Playlist signature verification failed`.

- [x] `npm run build` — clean
- [x] `npm run check` (format + lint + copy + tests) — **474/474 pass**

## Upstream note
dp1-js 2.2.0 also changes the signature bytes `SignMultiEIP191` *emits*. That does not affect ff-cli, which has no eip191 signing path, and existing `ed25519` signatures are unaffected in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)